### PR TITLE
Fix issue with react-native-gesture-handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8808,11 +8808,6 @@
         }
       }
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -16143,14 +16138,13 @@
       }
     },
     "react-native-gesture-handler": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.4.1.tgz",
-      "integrity": "sha512-Ffcs+SbEbkGaal0CClYL+v7A9y4OA5G5lW01qrzjxaqASp5C8BfnWSKuqYKE00s6bLwE5L4xnlHkG0yIxAtbrQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.3.0.tgz",
+      "integrity": "sha512-ASRFIXBuKRvqlmwkWJhV8yP2dTpvcqVrLNpd7FKVBFHYWr6SAxjGyO9Ik8w1lAxDhMlRP2IcJ9p9eq5X2WWeLQ==",
       "requires": {
-        "hammerjs": "^2.0.8",
         "hoist-non-react-statics": "^2.3.1",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.7.2"
+        "invariant": "^2.2.2",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-lifecycles-compat": "^3.0.4",
     "react-native": "https://github.com/expo/react-native/archive/sdk-34.0.0.tar.gz",
     "react-native-elements": "^1.1.0",
-    "react-native-gesture-handler": "^1.3.0",
+    "react-native-gesture-handler": "~1.3.0",
     "react-native-reanimated": "^1.1.0",
     "react-native-webview": "^5.12.1",
     "react-navigation": "^3.0.9"


### PR DESCRIPTION
Addresses an error due to an unsupported version of react-native-gesture-handler being installed.

Refs: https://forums.expo.io/t/new-warning-uimanager-getconstants-on-sdk-34-for-android/26929/6