### PR TITLE
Handle press on home tab when active

### DIFF
--- a/navigation/MainTabNavigator.js
+++ b/navigation/MainTabNavigator.js
@@ -37,7 +37,15 @@ HomeStack.navigationOptions = ({ navigation }) => {
         }
       />
     ),
-    tabBarVisible
+    tabBarVisible,
+    tabBarOnPress: ({ navigation, defaultHandler }) => {
+      const goHome = navigation.state && navigation.state.routes[0].params && navigation.state.routes[0].params.goHome;
+      if (navigation.isFocused() && typeof goHome === 'function') {
+        goHome();
+      } else {
+        defaultHandler();
+      }
+    }
   };
 };
 

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -73,6 +73,10 @@ export default class HomeScreen extends React.Component {
     });
   }
 
+  onGoHome() {
+    this.webview.injectJavaScript('window.Emby && window.Emby.Page && typeof window.Emby.Page.goHome === "function" && window.Emby.Page.goHome();');
+  }
+
   onRefresh() {
     this.setState({
       isLoading: true,
@@ -105,6 +109,9 @@ export default class HomeScreen extends React.Component {
   }
 
   componentDidMount() {
+    // Expose the goHome method to navigation props
+    this.props.navigation.setParams({ goHome: () => this.onGoHome() });
+    // Bootstrap component state
     this.bootstrapAsync();
   }
 


### PR DESCRIPTION
This implements a common iOS behavior. When a user taps the home tab and the home screen is already active we navigate to the initial screen in the webview.