### PR TITLE
Detect internal HTTPS redirects when detecting external sites

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -189,7 +189,10 @@ export default class HomeScreen extends React.Component {
                 return;
               }
 
-              if ((this.state.serverUrl && !url.startsWith(this.state.serverUrl)) || url.includes('/System/Logs/Log')) {
+                if ((this.state.serverUrl && 
+                        !url.startsWith(this.state.serverUrl) && 
+                        !url.startsWith(this.state.serverUrl.replace(new RegExp("^http://"),"https://"))) 
+                        || url.includes('/System/Logs/Log')) {
                 console.log('Opening browser for external url', url);
                 try {
                   await WebBrowser.openBrowserAsync(url, {

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -191,7 +191,7 @@ export default class HomeScreen extends React.Component {
 
                 if ((this.state.serverUrl && 
                         !url.startsWith(this.state.serverUrl) && 
-                        !url.startsWith(this.state.serverUrl.replace(new RegExp("^http://"),"https://"))) 
+                        !url.startsWith(this.state.serverUrl.replace(/^http:\/\//i, "https://"))) 
                         || url.includes('/System/Logs/Log')) {
                 console.log('Opening browser for external url', url);
                 try {


### PR DESCRIPTION
If a server address is entered with HTTP or no protocol, handle URLs with both HTTP and HTTPS as internal sites and do not open a browser.

It may be better to find some method of "following" redirects so we can determine exactly where the "real" address is located.That way we can handle redirects more complicated than HTTP -> HTTPS. If that seems too overboard, this should be enough to catch the situations where people don't type in a protocol.