### PR TITLE
Add required keys for submission

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,8 +24,9 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "org.jellyfin.expo"
     },
-    "description": ""
+    "description": "Jellyfin Expo Client"
   }
 }


### PR DESCRIPTION
Without these keys in place, the app will not build with Expo Turtle.