### PR TITLE
changed  "orientation" in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
       "android"
     ],
     "version": "0.1.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "primaryColor": "#00a4dc",
     "icon": "./assets/images/icon.png",
     "splash": {


### PR DESCRIPTION
This should fix issue: https://github.com/jellyfin/jellyfin-expo/issues/21

I just changed the value for "**orientation**" from "portrait" to "default"

This lets the iPad stay in landscape and not force it to portrait on app mount.

more info at expo docs here: https://docs.expo.io/versions/latest/workflow/configuration/#orientation