### PR TITLE
Fix live tv playback for Android

### DIFF
--- a/utils/NativeShell.js
+++ b/utils/NativeShell.js
@@ -71,12 +71,12 @@ window.NativeShell = {
 
     getDeviceProfile: function(profileBuilder) {
       postExpoEvent('AppHost.getDeviceProfile');
-      return profileBuilder();
+      return profileBuilder({ enableMkvProgressive: false });
     },
 
     getSyncProfile: function(profileBuilder) {
       postExpoEvent('AppHost.getSyncProfile');
-      return profileBuilder();
+      return profileBuilder({ enableMkvProgressive: false });
     },
 
     supports: function(command) {


### PR DESCRIPTION
This fixes an issue where Live TV streams would try to transcode to mkv which results in a NoCompatibleStream error on Android. It was introduced by the NativeShell implementation. This is set by default in jellyfin-web https://github.com/jellyfin/jellyfin-web/blob/master/src/components/apphost.js#L18.

Related to: https://github.com/jellyfin/jellyfin-android/issues/108