### PR TITLE
Add request timeout when validating server url

### DIFF
--- a/utils/JellyfinValidator.js
+++ b/utils/JellyfinValidator.js
@@ -7,7 +7,7 @@
 import Url from 'url';
 
 export default class JellyfinValidator {
-  static TIMEOUT_DURATION = 2000 // timeout request after 2s
+  static TIMEOUT_DURATION = 5000 // timeout request after 5s
 
   static parseUrl(host = '', port = '') {
     if (!host) {


### PR DESCRIPTION
This addresses an issue reported via TestFlight where an invalid server url causes the loading spinner to displayed for a _long_ time which seems like the app has stopped responding.

![waiting](https://user-images.githubusercontent.com/3450688/74187852-5f9a5800-4c1b-11ea-8556-dda0c79c88f3.gif)
