### PR TITLE
Fix orientation locking

### DIFF
--- a/App.js
+++ b/App.js
@@ -27,11 +27,9 @@ export default class App extends React.Component {
   };
 
   componentDidMount() {
-    // Allow screen rotation on iPad
-    if (Platform.OS === 'ios' && Platform.isPad) {
-      ScreenOrientation.lockAsync(
-        ScreenOrientation.OrientationLock.ALL
-      );
+    // Lock portrait orientation on iPhone
+    if (Platform.OS === 'ios' && !Platform.isPad) {
+      ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
     }
   }
 

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -144,14 +144,15 @@ class HomeScreen extends React.Component {
   }
 
   updateScreenOrientation() {
-    if (this.state.isFullscreen) {
-      // Lock to landscape orientation
-      console.debug('locking orientation to landscape');
-      ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE);
-    } else {
-      console.debug('removing orientation lock');
-      // Remove the orientation lock
-      ScreenOrientation.unlockAsync();
+    if (Platform.OS === 'ios' && !Platform.isPad) {
+      if (this.state.isFullscreen) {
+        // Lock to landscape orientation
+        // For some reason video apps on iPhone use LANDSCAPE_RIGHT ¯\_(ツ)_/¯
+        ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT);
+      } else {
+        // Restore portrait orientation lock
+        ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+      }
     }
   }
 


### PR DESCRIPTION
Changes orientation lock behavior:
* iPhone portrait lock when browsing and landscape lock during video playback
* iPad no orientation lock

![homer circles](https://user-images.githubusercontent.com/3450688/80150288-27ea4d80-8586-11ea-8df0-7caf20dc744d.gif)

Fixes #47 