### PR TITLE
Fix issues routing between Main and AddServer screens

### DIFF
--- a/components/ServerInput.js
+++ b/components/ServerInput.js
@@ -77,7 +77,13 @@ class ServerInput extends React.Component {
         this.props.onSuccess();
       }
       // Navigate to the main screen
-      this.props.navigation.navigate(this.props.successScreen || 'Main', { activeServer: servers.length - 1 });
+      this.props.navigation.reset({
+        index: 0,
+        routes: [{
+          name: this.props.successScreen || 'Main',
+          props: { activeServer: servers.length - 1 }
+        }]
+      });
     } else {
       this.setState({
         isValid: false,

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -85,26 +85,28 @@ function AppNavigator() {
 
   return (
     <NavigationContainer theme={theme}>
-      <Stack.Navigator headerMode='screen' screenOptions={{ headerShown: false }}>
-        {(servers && servers.length > 0) ?
-          <Stack.Screen
-            name='Main'
-            component={Main}
-            options={({ route }) => {
-              const routeName = route.state ?
-                // Get the currently active route name in the tab navigator
-                route.state.routes[route.state.index].name :
-                // If state doesn't exist, we need to default to `screen` param if available, or the initial screen
-                // In our case, it's "Main" as that's the first screen inside the navigator
-                route.params?.screen || 'Main';
-              return ({
-                headerShown: routeName === 'Settings',
-                title: routeName
-              });
-            }}
-          /> :
-          <Stack.Screen name='AddServer' component={AddServerScreen} />
-        }
+      <Stack.Navigator
+        initialRouteName={(servers && servers.length > 0) ? 'Main' : 'AddServer'}
+        headerMode='screen'
+        screenOptions={{ headerShown: false }}
+      >
+        <Stack.Screen
+          name='Main'
+          component={Main}
+          options={({ route }) => {
+            const routeName = route.state ?
+              // Get the currently active route name in the tab navigator
+              route.state.routes[route.state.index].name :
+              // If state doesn't exist, we need to default to `screen` param if available, or the initial screen
+              // In our case, it's "Main" as that's the first screen inside the navigator
+              route.params?.screen || 'Main';
+            return ({
+              headerShown: routeName === 'Settings',
+              title: routeName
+            });
+          }}
+        />
+        <Stack.Screen name='AddServer' component={AddServerScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -166,9 +166,17 @@ class SettingsScreen extends React.Component {
     // Remove one server at index
     servers.splice(index, 1);
     // Save to storage cache
+    await CachingStorage.getInstance().setItem(StorageKeys.ActiveServer, 0);
     await CachingStorage.getInstance().setItem(StorageKeys.Servers, servers);
-    // Navigate to the loading screen
-    this.props.navigation.navigate('Loading');
+
+    if (servers.length > 0) {
+      // More servers exist, update state and navigate home
+      this.bootstrapAsync();
+      this.props.navigation.navigate('Home', { activeServer: 0 });
+    } else {
+      // No servers are present, navigate to add server screen
+      this.props.navigation.navigate('AddServer');
+    }
   }
 
   async resetApplication() {
@@ -177,7 +185,7 @@ class SettingsScreen extends React.Component {
     // Reset the storage cache
     CachingStorage.instance = null;
     // Navigate to the loading screen
-    this.props.navigation.navigate('Loading');
+    this.props.navigation.navigate('AddServer');
   }
 
   onDeleteServer(index) {


### PR DESCRIPTION
The `Main` and `AddServer` screens were not both present in the navigation stack. This caused issues when entering a server for the first time, resetting the application, or removing the last server in the app.