### PR TITLE
Disable all screen locking

### DIFF
--- a/App.js
+++ b/App.js
@@ -28,9 +28,9 @@ export default class App extends React.Component {
 
   componentDidMount() {
     // Lock portrait orientation on iPhone
-    if (Platform.OS === 'ios' && !Platform.isPad) {
-      ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
-    }
+    // if (Platform.OS === 'ios' && !Platform.isPad) {
+    //   ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+    // }
   }
 
   render() {

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -177,7 +177,7 @@ class HomeScreen extends React.Component {
     }
     if (prevState.isFullscreen !== this.state.isFullscreen) {
       // Update the screen orientation
-      this.updateScreenOrientation();
+      // this.updateScreenOrientation();
       // Show/hide the bottom tab bar
       this.props.navigation.setOptions({
         tabBarVisible: !this.state.isFullscreen


### PR DESCRIPTION
Continuing to experiment with #74.

This disables all screen orientation locking in our code to see if maybe the issue comes from a dependency or a failure in our check for iPhones.