### PR TITLE
Fix huge logo on add server screen

### DIFF
--- a/screens/AddServerScreen.js
+++ b/screens/AddServerScreen.js
@@ -13,7 +13,7 @@ export default class AddServerScreen extends React.Component {
   render() {
     return (
       <View style={styles.container}>
-        <View style={styles.container}>
+        <View style={styles.logoContainer}>
           <Image
             style={styles.logoImage}
             source={require('../assets/images/logowhite.png')}
@@ -30,7 +30,7 @@ export default class AddServerScreen extends React.Component {
 
 const styles = StyleSheet.create({
   serverTextContainer: {
-    flex: 1.5,
+    flex: 1,
     alignContent: 'flex-start'
   },
   container: {
@@ -39,10 +39,17 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: Colors.backgroundColor
   },
+  logoContainer: {
+    marginTop: 80,
+    marginBottom: 48,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
   logoImage: {
-    marginBottom: 12,
     width: '90%',
     height: undefined,
+    maxWidth: 481,
+    maxHeight: 151,
     // Aspect ration of the logo
     aspectRatio: 3.18253
   }


### PR DESCRIPTION
The logo was _yuge_ on iPad devices especially when in landscape orientation. This sets a maximum size on the logo and adjusts the vertical positioning on the screen.

## Portrait

### Old
![5D6B5939-8305-4FED-90AA-795A4D343377](https://user-images.githubusercontent.com/3450688/84529341-4aa80100-acaf-11ea-941e-c5e7ab15d8d1.png)

### New
![A08FA1EB-FCAB-4DFA-8589-D9A410D482B3](https://user-images.githubusercontent.com/3450688/84529386-5eebfe00-acaf-11ea-9ce2-3d8ec56321c3.png)


## Landscape

### Old
![94C6913D-D921-403D-8B0B-809A6B7DAB64](https://user-images.githubusercontent.com/3450688/84529420-6e6b4700-acaf-11ea-9fe8-ccaf4a979f9c.png)

### New
![A34251B2-8AD9-47A0-A06D-5362CF62E049](https://user-images.githubusercontent.com/3450688/84529459-7b883600-acaf-11ea-9c91-9ce1ece4e537.png)
