### PR TITLE
Allow either landscape direction after initial rotation

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -154,12 +154,14 @@ class HomeScreen extends React.Component {
     this.setState({ isRefreshing: false });
   }
 
-  updateScreenOrientation() {
+  async updateScreenOrientation() {
     if (Platform.OS === 'ios' && !Platform.isPad) {
       if (this.state.isFullscreen) {
         // Lock to landscape orientation
         // For some reason video apps on iPhone use LANDSCAPE_RIGHT ¯\_(ツ)_/¯
-        ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT);
+        await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT);
+        // Allow either landscape orientation after forcing initial rotation
+        ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE);
       } else {
         // Restore portrait orientation lock
         ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);


### PR DESCRIPTION
This is something of a hack to make sure our rotation lock works like other apps.

All other video apps rotate to LANDSCAPE_RIGHT by default and then allow either LANDSCAPE orientation. If we only lock to LANDSCAPE, then the app will rotate to LANDSCAPE_LEFT. To avoid this we lock to LANDSCAPE_RIGHT and then lock to LANDSCAPE.

Addresses the issue mentioned in [this comment](https://github.com/jellyfin/jellyfin-expo/issues/74#issuecomment-632313853).

![helicopter spinning](https://user-images.githubusercontent.com/3450688/85171563-3d55be00-b23d-11ea-9d58-f06898367228.gif)
