### PR TITLE
Revert "Possible fix for initial orientation change on iPads"

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,6 +9,7 @@
       "android"
     ],
     "version": "1.1.2",
+    "orientation": "default",
     "primaryColor": "#00a4dc",
     "icon": "./assets/images/icon.png",
     "splash": {


### PR DESCRIPTION
This had no affect on the iPad orientation issue, so we should probably restore the setting.