### PR TITLE
Prevent going back when no servers are added

### DIFF
--- a/components/ServerInput.js
+++ b/components/ServerInput.js
@@ -77,13 +77,13 @@ class ServerInput extends React.Component {
         this.props.onSuccess();
       }
       // Navigate to the main screen
-      this.props.navigation.reset({
-        index: 0,
-        routes: [{
-          name: this.props.successScreen || 'Main',
-          props: { activeServer: this.props.rootStore.settingStore.activeServer }
-        }]
-      });
+      this.props.navigation.replace(
+        'Main',
+        {
+          screen: this.props.successScreen || 'Home',
+          params: { activeServer: this.props.rootStore.settingStore.activeServer }
+        }
+      );
     } else {
       this.setState({
         isValid: false,

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -168,7 +168,7 @@ class SettingsScreen extends React.Component {
       this.props.navigation.navigate('Home', { activeServer: 0 });
     } else {
       // No servers are present, navigate to add server screen
-      this.props.navigation.navigate('AddServer');
+      this.props.navigation.replace('AddServer');
     }
   }
 
@@ -177,7 +177,7 @@ class SettingsScreen extends React.Component {
     this.props.rootStore.serverStore.servers = [];
     this.props.rootStore.settingStore.activeServer = 0;
     // Navigate to the loading screen
-    this.props.navigation.navigate('AddServer');
+    this.props.navigation.replace('AddServer');
   }
 
   onDeleteServer(index) {


### PR DESCRIPTION
This addresses a bug where a user could swipe to navigate back to the main app screen after removing all servers.