### PR TITLE
Remove add server overlay

### DIFF
--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -91,7 +91,14 @@ const AppNavigator = observer(() => {
             });
           }}
         />
-        <Stack.Screen name='AddServer' component={AddServerScreen} />
+        <Stack.Screen
+          name='AddServer'
+          component={AddServerScreen}
+          options={{
+            headerShown: serverStore.servers.length > 0,
+            title: 'Add Server'
+          }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -95,7 +95,7 @@ const AppNavigator = observer(() => {
           name='AddServer'
           component={AddServerScreen}
           options={{
-            headerShown: serverStore.servers.length > 0,
+            headerShown: rootStore.serverStore.servers.length > 0,
             title: 'Add Server'
           }}
         />

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -13,7 +13,7 @@ import {
   StyleSheet,
   View
 } from 'react-native';
-import { Button, colors, ListItem, Text, Icon, Overlay } from 'react-native-elements';
+import { Button, colors, ListItem, Text, Icon } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { observer } from 'mobx-react';
@@ -22,7 +22,6 @@ import Url from 'url';
 import PropTypes from 'prop-types';
 
 import { useStores } from '../hooks/useStores';
-import ServerInput from '../components/ServerInput';
 import SettingsSection from '../components/SettingsSection';
 import Colors from '../constants/Colors';
 import Links from '../constants/Links';
@@ -38,7 +37,6 @@ class SettingsScreen extends React.Component {
   }
 
   state = {
-    isAddServerVisible: false,
     servers: null
   };
 
@@ -232,7 +230,7 @@ class SettingsScreen extends React.Component {
           <Button
             buttonStyle={{ margin: 15 }}
             title='Add Server'
-            onPress={() => this.setState({ isAddServerVisible: true })}
+            onPress={() => this.props.navigation.navigate('AddServer')}
           />
 
           <SettingsSection heading='Links'>
@@ -259,20 +257,6 @@ class SettingsScreen extends React.Component {
             <Text style={styles.infoText}>{`Expo Version: ${Constants.expoVersion}`}</Text>
           </View>
         </ScrollView>
-
-        <Overlay
-          height={'auto'}
-          isVisible={this.state.isAddServerVisible}
-          onBackdropPress={() => this.setState({ isAddServerVisible: false })}
-        >
-          <ServerInput
-            onSuccess={() => {
-              this.setState({ isAddServerVisible: false });
-              this.bootstrapAsync();
-            }}
-            successScreen={'Home'}
-          />
-        </Overlay>
       </SafeAreaView>
     );
   }


### PR DESCRIPTION
This replaces the add server overlay in the settings screen with the add server screen used for initial setup. The overlay felt out of place on iOS and this allows us to reuse an existing screen.

### Before:
![IMG_4144](https://user-images.githubusercontent.com/3450688/85756162-8fcf2880-b6dc-11ea-8ea7-a49f97c6b61b.PNG)

### After:
![IMG_4143](https://user-images.githubusercontent.com/3450688/85755776-39fa8080-b6dc-11ea-8561-33b25dd5b54f.PNG)

Depends on #93 