### PR TITLE
Add name to delete server alert

### DIFF
--- a/components/ServerListItem.js
+++ b/components/ServerListItem.js
@@ -14,16 +14,9 @@ import { getIconName } from '../utils/Icons';
 const ServerListItem = ({item, index, activeServer, onDelete, onPress}) => {
   const { t } = useTranslation();
 
-  let title;
-  let subtitle;
-  if (item.info) {
-    title = item.info.ServerName;
-    subtitle = t('settings.version', { version: item.info.Version });
-  } else {
-    title = item.url.host;
-    subtitle = t('settings.version', { version: t('common.unknown') });
-  }
-  subtitle += `\n${item.urlString}`;
+  const title = item?.name;
+  const version = item?.info?.Version || t('common.unknown');
+  const subtitle = `${t('settings.version', { version })}\n${item.urlString}`;
 
   return (
     <ListItem

--- a/langs/en.json
+++ b/langs/en.json
@@ -40,7 +40,7 @@
   "alerts": {
     "deleteServer": {
       "title": "Delete Server",
-      "description": "Are you sure you want to delete this server?",
+      "description": "Are you sure you want to delete the server {{serverName}}?",
       "confirm": "Delete"
     },
     "resetApplication": {

--- a/models/ServerModel.js
+++ b/models/ServerModel.js
@@ -28,6 +28,10 @@ export default class ServerModel {
     });
   }
 
+  get name() {
+    return this.info?.ServerName || this.url?.host;
+  }
+
   get parseUrlString() {
     try {
       return JellyfinValidator.getServerUrl(this);
@@ -56,5 +60,6 @@ decorate(ServerModel, {
     observable
   ],
   info: observable,
+  name: computed,
   parseUrlString: computed
 });

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -35,9 +35,11 @@ const SettingsScreen = observer(() => {
   };
 
   const onDeleteServer = index => {
+    const serverName = rootStore.serverStore.servers[index]?.info?.ServerName || rootStore.serverStore.servers[index]?.url.host;
+
     Alert.alert(
       t('alerts.deleteServer.title'),
-      t('alerts.deleteServer.description'),
+      t('alerts.deleteServer.description', { serverName }),
       [
         { text: t('common.cancel') },
         {

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -35,11 +35,9 @@ const SettingsScreen = observer(() => {
   };
 
   const onDeleteServer = index => {
-    const serverName = rootStore.serverStore.servers[index]?.info?.ServerName || rootStore.serverStore.servers[index]?.url.host;
-
     Alert.alert(
       t('alerts.deleteServer.title'),
-      t('alerts.deleteServer.description', { serverName }),
+      t('alerts.deleteServer.description', { serverName: rootStore.serverStore.servers[index]?.name }),
       [
         { text: t('common.cancel') },
         {


### PR DESCRIPTION
* Adds the server name to the delete server confirmation dialog (as suggested [on Reddit](https://old.reddit.com/r/jellyfin/comments/htg0rp/call_for_translators_for_ios_app/fyivi4u/)).
* Moves the logic for getting the server name to a computed field in the model