### PR TITLE
Refactor HomeScreen and fix pull to refresh

### DIFF
--- a/App.js
+++ b/App.js
@@ -79,6 +79,26 @@ const App = observer(({ skipLoadingScreen }) => {
 		}
 	}, [rootStore.settingStore.isRotationEnabled]);
 
+	const updateScreenOrientation = async () => {
+		if (rootStore.settingStore.isRotationEnabled) {
+			if (rootStore.isFullscreen) {
+				// Lock to landscape orientation
+				// For some reason video apps on iPhone use LANDSCAPE_RIGHT ¯\_(ツ)_/¯
+				await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT);
+				// Allow either landscape orientation after forcing initial rotation
+				ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE);
+			} else {
+				// Restore portrait orientation lock
+				ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+			}
+		}
+	};
+
+	useEffect(() => {
+		// Update the screen orientation
+		updateScreenOrientation();
+	}, [rootStore.isFullscreen]);
+
 	const loadImagesAsync = () => {
 		const images = [
 			require('./assets/images/splash.png'),
@@ -114,6 +134,7 @@ const App = observer(({ skipLoadingScreen }) => {
 				<StatusBar
 					style="light"
 					backgroundColor={Colors.headerBackgroundColor}
+					hidden={rootStore.isFullscreen}
 				/>
 				<AppNavigator />
 			</ThemeProvider>

--- a/components/NativeShellWebView.js
+++ b/components/NativeShellWebView.js
@@ -1,0 +1,130 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { action } from 'mobx';
+import { observer } from 'mobx-react';
+import Constants from 'expo-constants';
+import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
+
+import { useStores } from '../hooks/useStores';
+import { getAppName, getSafeDeviceName } from '../utils/Device';
+import NativeShell from '../utils/NativeShell';
+import { openBrowser } from '../utils/WebBrowser';
+import RefreshWebView from './RefreshWebView';
+
+const injectedJavaScript = `
+window.ExpoAppInfo = {
+  appName: '${getAppName()}',
+  appVersion: '${Constants.nativeAppVersion}',
+  deviceId: '${Constants.deviceId}',
+  deviceName: '${getSafeDeviceName().replace(/'/g, '\\\'')}'
+};
+
+${NativeShell}
+
+true;
+`;
+
+const NativeShellWebView = observer((props) => {
+	const { rootStore } = useStores();
+	const navigation = useNavigation();
+	const [isRefreshing, setIsRefreshing] = useState(false);
+	const webview = useRef(null);
+
+	const server = rootStore.serverStore.servers[rootStore.settingStore.activeServer];
+
+	useEffect(() => {
+		navigation.addListener('tabPress', e => {
+			if (navigation.isFocused()) {
+				// Prevent default behavior
+				e.preventDefault();
+				// Call the web router to navigate home
+				webview.current?.injectJavaScript('window.Emby && window.Emby.Page && typeof window.Emby.Page.goHome === "function" && window.Emby.Page.goHome();');
+			}
+		});
+	}, []);
+
+	const onRefresh = () => {
+		// Disable pull to refresh when in fullscreen
+		if (rootStore.isFullscreen) return;
+		setIsRefreshing(true);
+		webview.current?.reload();
+		setIsRefreshing(false);
+	};
+
+	const onMessage = action(({ nativeEvent: state }) => {
+		try {
+			const { event, data } = JSON.parse(state.data);
+			switch (event) {
+				case 'enableFullscreen':
+					rootStore.isFullscreen = true;
+					break;
+				case 'disableFullscreen':
+					rootStore.isFullscreen = false;
+					break;
+				case 'openUrl':
+					console.log('Opening browser for external url', data.url);
+					openBrowser(data.url);
+					break;
+				case 'updateMediaSession':
+					// Keep the screen awake when music is playing
+					if (rootStore.settingStore.isScreenLockEnabled) {
+						activateKeepAwake();
+					}
+					break;
+				case 'hideMediaSession':
+					// When music session stops disable keep awake
+					if (rootStore.settingStore.isScreenLockEnabled) {
+						deactivateKeepAwake();
+					}
+					break;
+				case 'console.debug':
+					// console.debug('[Browser Console]', data);
+					break;
+				case 'console.error':
+					console.error('[Browser Console]', data);
+					break;
+				case 'console.info':
+					// console.info('[Browser Console]', data);
+					break;
+				case 'console.log':
+					// console.log('[Browser Console]', data);
+					break;
+				case 'console.warn':
+					console.warn('[Browser Console]', data);
+					break;
+				default:
+					console.debug('[HomeScreen.onMessage]', event, data);
+			}
+		} catch (ex) {
+			console.warn('Exception handling message', state.data);
+		}
+	});
+
+	return (
+		<RefreshWebView
+			ref={webview}
+			source={{ uri: server.urlString }}
+			// Inject javascript for NativeShell
+			injectedJavaScriptBeforeContentLoaded={injectedJavaScript}
+			onMessage={onMessage}
+			isRefreshing={isRefreshing}
+			onRefresh={onRefresh}
+			// Pass through additional props
+			{...props}
+			// Make scrolling feel faster
+			decelerationRate='normal'
+			// Media playback options to fix video player
+			allowsInlineMediaPlayback={true}
+			mediaPlaybackRequiresUserAction={false}
+			// Use WKWebView on iOS
+			useWebKit={true}
+		/>
+	);
+});
+
+export default NativeShellWebView;

--- a/components/OfflineErrorView.js
+++ b/components/OfflineErrorView.js
@@ -1,0 +1,52 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Button, Text } from 'react-native-elements';
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+
+import Colors from '../constants/Colors';
+import { getIconName } from '../utils/Icons';
+
+const OfflineErrorView = ({ onRetry }) => {
+	const { t } = useTranslation();
+
+	return (
+		<View style={styles.container}>
+			<Text style={styles.error}>{t('home.offline')}</Text>
+			<Button
+				buttonStyle={{
+					marginLeft: 15,
+					marginRight: 15
+				}}
+				icon={{
+					name: getIconName('refresh'),
+					type: 'ionicon'
+				}}
+				title={t('home.retry')}
+				onPress={onRetry}
+			/>
+		</View>);
+};
+
+OfflineErrorView.propTypes = {
+	onRetry: PropTypes.func.isRequired
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		backgroundColor: Colors.backgroundColor
+	},
+	error: {
+		fontSize: 17,
+		paddingBottom: 17,
+		textAlign: 'center'
+	}
+});
+
+export default OfflineErrorView;

--- a/components/RefreshWebView.js
+++ b/components/RefreshWebView.js
@@ -1,0 +1,62 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import React, { useState } from 'react';
+import { WebView } from 'react-native-webview';
+import { RefreshControl, Dimensions, StyleSheet } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
+import PropTypes from 'prop-types';
+
+const RefreshWebView = React.forwardRef(
+	function RefreshWebView({ isRefreshing, onRefresh, refreshControlProps, ...webViewProps }, ref) {
+		const [height, setHeight] = useState(Dimensions.get('screen').height);
+		const [isEnabled, setEnabled] = useState(typeof onRefresh === 'function');
+
+		return (
+			<ScrollView
+				onLayout={(e) => setHeight(e.nativeEvent.layout.height)}
+				refreshControl={
+					<RefreshControl
+						onRefresh={onRefresh}
+						refreshing={isRefreshing}
+						enabled={isEnabled}
+						{...refreshControlProps}
+					/>
+				}
+				style={styles.view}>
+				<WebView
+					ref={ref}
+					{...webViewProps}
+					onScroll={(e) =>
+						setEnabled(
+							typeof onRefresh === 'function' &&
+							e.nativeEvent.contentOffset.y === 0
+						)
+					}
+					style={{
+						...styles.view,
+						height,
+						...webViewProps.style
+					}}
+				/>
+			</ScrollView>
+		);
+	}
+);
+
+RefreshWebView.propTypes = {
+	isRefreshing: PropTypes.bool.isRequired,
+	onRefresh: PropTypes.func,
+	refreshControlProps: PropTypes.any
+};
+
+const styles = StyleSheet.create({
+	view: {
+		flex: 1,
+		height: '100%'
+	}
+});
+
+export default RefreshWebView;

--- a/components/ServerInput.js
+++ b/components/ServerInput.js
@@ -7,6 +7,7 @@ import React from 'react';
 import { ActivityIndicator, Platform, StyleSheet } from 'react-native';
 import { Input, colors } from 'react-native-elements';
 import { useNavigation } from '@react-navigation/native';
+import { action } from 'mobx';
 import { observer } from 'mobx-react';
 import PropTypes from 'prop-types';
 
@@ -33,7 +34,7 @@ const ServerInput = observer(class ServerInput extends React.Component {
 		validationMessage: ''
 	}
 
-	async onAddServer() {
+	onAddServer = action(async () => {
 		const { host } = this.state;
 		console.log('add server', host);
 		if (host) {
@@ -92,7 +93,7 @@ const ServerInput = observer(class ServerInput extends React.Component {
 				validationMessage: this.props.t('addServer.validation.empty')
 			});
 		}
-	}
+	})
 
 	render() {
 		return (

--- a/constants/Colors.js
+++ b/constants/Colors.js
@@ -5,22 +5,22 @@
  */
 const backgroundColor = '#101010';
 const textColor = '#fff';
-const jellyBlue = '#00a4dc';
-const jellyPurple = '#AA5CC3';
+const primaryBlue = '#00a4dc';
+const primaryPurple = '#AA5CC3';
 
 export default {
-	jellyBlue,
-	jellyPurple,
+	primaryBlue,
+	primaryPurple,
 	textColor,
 	backgroundColor,
 	headerBackgroundColor: '#202020',
-	tintColor: jellyBlue,
+	tintColor: primaryBlue,
 	headerTintColor: textColor,
 	tabText: '#ccc',
 	errorBackground: 'red',
 	errorText: textColor,
 	warningBackground: '#EAEB5E',
 	warningText: '#666804',
-	noticeBackground: jellyBlue,
+	noticeBackground: primaryBlue,
 	noticeText: textColor
 };

--- a/constants/Colors.js
+++ b/constants/Colors.js
@@ -5,19 +5,22 @@
  */
 const backgroundColor = '#101010';
 const textColor = '#fff';
-const tintColor = '#00a4dc';
+const jellyBlue = '#00a4dc';
+const jellyPurple = '#AA5CC3';
 
 export default {
+	jellyBlue,
+	jellyPurple,
 	textColor,
 	backgroundColor,
 	headerBackgroundColor: '#202020',
-	tintColor,
+	tintColor: jellyBlue,
 	headerTintColor: textColor,
 	tabText: '#ccc',
 	errorBackground: 'red',
 	errorText: textColor,
 	warningBackground: '#EAEB5E',
 	warningText: '#666804',
-	noticeBackground: tintColor,
+	noticeBackground: jellyBlue,
 	noticeText: textColor
 };

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -97,11 +97,11 @@ const AppNavigator = observer(() => {
 					component={Main}
 					options={({ route }) => {
 						const routeName = route.state ?
-						// Get the currently active route name in the tab navigator
+							// Get the currently active route name in the tab navigator
 							route.state.routes[route.state.index].name :
-              // If state doesn't exist, we need to default to `screen` param if available, or the initial screen
-              // In our case, it's "Main" as that's the first screen inside the navigator
-              route.params?.screen || 'Main';
+							// If state doesn't exist, we need to default to `screen` param if available, or the initial screen
+							// In our case, it's "Main" as that's the first screen inside the navigator
+							route.params?.screen || 'Main';
 						return ({
 							headerShown: routeName === 'Settings',
 							title: t(`headings.${routeName.toLowerCase()}`)

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -55,7 +55,7 @@ const HomeScreen = observer(() => {
 						tintColor: Colors.tabText,
 						backgroundColor: Colors.headerBackgroundColor,
 						// Android colors
-						colors: [Colors.jellyBlue, Colors.jellyPurple],
+						colors: [Colors.primaryBlue, Colors.primaryPurple],
 						progressBackgroundColor: Colors.backgroundColor
 					}}
 					// Error screen is displayed if loading fails

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -3,252 +3,79 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
-import { Platform, RefreshControl, StyleSheet, ScrollView, View } from 'react-native';
-import { Button, Text } from 'react-native-elements';
+import React, { useEffect, useState } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { WebView } from 'react-native-webview';
-import { useNavigation, useRoute } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { observer } from 'mobx-react';
 import Constants from 'expo-constants';
-import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
-import * as ScreenOrientation from 'expo-screen-orientation';
-import { setStatusBarHidden } from 'expo-status-bar';
-import PropTypes from 'prop-types';
-import { useTranslation } from 'react-i18next';
 
 import { useStores } from '../hooks/useStores';
+import NativeShellWebView from '../components/NativeShellWebView';
+import OfflineErrorView from '../components/OfflineErrorView';
 import Colors from '../constants/Colors';
-import { getAppName, getSafeDeviceName } from '../utils/Device';
-import { getIconName } from '../utils/Icons';
-import NativeShell from '../utils/NativeShell';
-import { openBrowser } from '../utils/WebBrowser';
 
-const injectedJavaScript = `
-window.ExpoAppInfo = {
-	appName: '${getAppName()}',
-	appVersion: '${Constants.nativeAppVersion}',
-	deviceId: '${Constants.deviceId}',
-	deviceName: '${getSafeDeviceName().replace(/'/g, '\\\'')}'
-};
+const HomeScreen = observer(() => {
+	const { rootStore } = useStores();
+	const navigation = useNavigation();
 
-${NativeShell}
+	const [isError, setIsError] = useState(false);
+	const [isLoading, setIsLoading] = useState(true);
 
-true;
-`;
+	useEffect(() => {
+		// Show/hide the bottom tab bar
+		navigation.setOptions({
+			tabBarVisible: !rootStore.isFullscreen
+		});
+	}, [rootStore.isFullscreen]);
 
-const HomeScreen = observer(class HomeScreen extends React.Component {
-	state = {
-		isError: false,
-		isFullscreen: false,
-		isLoading: true,
-		isRefreshing: false
-	};
-
-	static propTypes = {
-		navigation: PropTypes.object.isRequired,
-		route: PropTypes.object.isRequired,
-		rootStore: PropTypes.object.isRequired,
-		t: PropTypes.func.isRequired
+	// When not in fullscreen, the top adjustment is handled by the spacer View for iOS
+	const safeAreaEdges = ['right', 'bottom', 'left'];
+	if (Platform.OS !== 'ios' || rootStore.isFullscreen) {
+		safeAreaEdges.push('top');
 	}
+	// Hide webview until loaded
+	const webviewStyle = (isError || isLoading) ? styles.loading : styles.container;
 
-	getErrorView() {
-		const { t } = this.props;
+	if (!rootStore.serverStore.servers || rootStore.serverStore.servers.length === 0) {
+		return null;
+	}
+	const server = rootStore.serverStore.servers[rootStore.settingStore.activeServer];
 
-		return (
-			<View style={styles.container}>
-				<Text style={styles.error}>{t('home.offline')}</Text>
-				<Button
-					buttonStyle={{
-						marginLeft: 15,
-						marginRight: 15
+	return (
+		<SafeAreaView style={styles.container} edges={safeAreaEdges} >
+			{Platform.OS === 'ios' && !rootStore.isFullscreen && (
+				<View style={styles.statusBarSpacer} />
+			)}
+			{server && server.urlString && (
+				<NativeShellWebView
+					style={webviewStyle}
+					refreshControlProps={{
+						// iOS colors
+						tintColor: Colors.tabText,
+						backgroundColor: Colors.headerBackgroundColor,
+						// Android colors
+						colors: [Colors.jellyBlue, Colors.jellyPurple],
+						progressBackgroundColor: Colors.backgroundColor
 					}}
-					icon={{
-						name: getIconName('refresh'),
-						type: 'ionicon'
+					// Error screen is displayed if loading fails
+					renderError={() => <OfflineErrorView onRetry={() => this.onRefresh()} />}
+					// Loading screen is displayed when refreshing
+					renderLoading={() => <View style={styles.container} />}
+					// Update state on loading error
+					onError={({ nativeEvent: state }) => {
+						console.warn('Error', state);
+						setIsError(true);
 					}}
-					title={t('home.retry')}
-					onPress={() => this.onRefresh()}
+					// Update state when loading is complete
+					onLoad={() => {
+						setIsError(false);
+						setIsLoading(false);
+					}}
 				/>
-			</View>
-		);
-	}
-
-	onGoHome() {
-		this.webview.injectJavaScript('window.Emby && window.Emby.Page && typeof window.Emby.Page.goHome === "function" && window.Emby.Page.goHome();');
-	}
-
-	async onMessage({ nativeEvent: state }) {
-		try {
-			const { event, data } = JSON.parse(state.data);
-			switch (event) {
-				case 'enableFullscreen':
-					this.setState({ isFullscreen: true });
-					break;
-				case 'disableFullscreen':
-					this.setState({ isFullscreen: false });
-					break;
-				case 'openUrl':
-					console.log('Opening browser for external url', data.url);
-					openBrowser(data.url);
-					break;
-				case 'updateMediaSession':
-					// Keep the screen awake when music is playing
-					if (this.props.rootStore.settingStore.isScreenLockEnabled) {
-						activateKeepAwake();
-					}
-					break;
-				case 'hideMediaSession':
-					// When music session stops disable keep awake
-					if (this.props.rootStore.settingStore.isScreenLockEnabled) {
-						deactivateKeepAwake();
-					}
-					break;
-				case 'console.debug':
-					console.debug('[Browser Console]', data);
-					break;
-				case 'console.error':
-					console.error('[Browser Console]', data);
-					break;
-				case 'console.info':
-					console.info('[Browser Console]', data);
-					break;
-				case 'console.log':
-					console.log('[Browser Console]', data);
-					break;
-				case 'console.warn':
-					console.warn('[Browser Console]', data);
-					break;
-				default:
-					console.debug('[HomeScreen.onMessage]', event, data);
-			}
-		} catch (ex) {
-			console.warn('Exception handling message', state.data);
-		}
-	}
-
-	onRefresh() {
-		// Disable pull to refresh when in fullscreen
-		if (this.state.isFullscreen) return;
-
-		this.setState({
-			isLoading: true,
-			isRefreshing: true
-		});
-		this.webview.reload();
-		this.setState({ isRefreshing: false });
-	}
-
-	async updateScreenOrientation() {
-		if (this.props.rootStore.settingStore.isRotationEnabled) {
-			if (this.state.isFullscreen) {
-				// Lock to landscape orientation
-				// For some reason video apps on iPhone use LANDSCAPE_RIGHT ¯\_(ツ)_/¯
-				await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT);
-				// Allow either landscape orientation after forcing initial rotation
-				ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE);
-			} else {
-				// Restore portrait orientation lock
-				ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
-			}
-		}
-	}
-
-	componentDidMount() {
-		// Override the default tab press behavior so a second press sends the webview home
-		this.props.navigation.addListener('tabPress', e => {
-			if (this.props.navigation.isFocused()) {
-				// Prevent default behavior
-				e.preventDefault();
-
-				this.onGoHome();
-			}
-		});
-	}
-
-	componentDidUpdate(prevProps, prevState) {
-		if (prevState.isFullscreen !== this.state.isFullscreen) {
-			// Update the screen orientation
-			this.updateScreenOrientation();
-			// Show/hide the bottom tab bar
-			this.props.navigation.setOptions({
-				tabBarVisible: !this.state.isFullscreen
-			});
-			// Show/hide the status bar
-			setStatusBarHidden(this.state.isFullscreen);
-		}
-	}
-
-	render() {
-		// When not in fullscreen, the top adjustment is handled by the spacer View for iOS
-		const safeAreaEdges = ['right', 'bottom', 'left'];
-		if (Platform.OS !== 'ios' || this.state.isFullscreen) {
-			safeAreaEdges.push('top');
-		}
-		// Hide webview until loaded
-		const webviewStyle = (this.state.isError || this.state.isLoading) ? styles.loading : styles.container;
-
-		if (!this.props.rootStore.serverStore.servers || this.props.rootStore.serverStore.servers.length === 0) {
-			return null;
-		}
-		const server = this.props.rootStore.serverStore.servers[this.props.rootStore.settingStore.activeServer];
-
-		return (
-			<SafeAreaView style={styles.container} edges={safeAreaEdges} >
-				{Platform.OS === 'ios' && !this.state.isFullscreen && (
-					<View style={styles.statusBarSpacer} />
-				)}
-				<ScrollView
-					style={styles.container}
-					contentContainerStyle={{flexGrow: 1}}
-					refreshControl={
-						Platform.OS === 'ios' ? (
-							<RefreshControl
-								refreshing={this.state.isRefreshing}
-								onRefresh={() => this.onRefresh()}
-								tintColor={Colors.tabText}
-							/>
-						) : null
-					}
-				>
-					{server && server.urlString && (
-						<WebView
-							ref={ref => (this.webview = ref)}
-							source={{ uri: server.urlString }}
-							style={webviewStyle}
-							// Inject javascript for NativeShell
-							injectedJavaScriptBeforeContentLoaded={injectedJavaScript}
-							// Handle messages from NativeShell
-							onMessage={this.onMessage.bind(this)}
-							// Make scrolling feel faster
-							decelerationRate='normal'
-							// Error screen is displayed if loading fails
-							renderError={() => this.getErrorView()}
-							// Loading screen is displayed when refreshing
-							renderLoading={() => <View style={styles.container} />}
-							// Update state on loading error
-							onError={({ nativeEvent: state }) => {
-								console.warn('Error', state);
-								this.setState({ isError: true });
-							}}
-							// Update state when loading is complete
-							onLoad={() => {
-								this.setState({
-									isError: false,
-									isLoading: false
-								});
-							}}
-							// Media playback options to fix video player
-							allowsInlineMediaPlayback={true}
-							mediaPlaybackRequiresUserAction={false}
-							// Use WKWebView on iOS
-							useWebKit={true}
-						/>
-					)}
-				</ScrollView>
-			</SafeAreaView>
-		);
-	}
+			)}
+		</SafeAreaView>
+	);
 });
 
 const styles = StyleSheet.create({
@@ -264,28 +91,7 @@ const styles = StyleSheet.create({
 	statusBarSpacer: {
 		backgroundColor: Colors.headerBackgroundColor,
 		height: Constants.statusBarHeight
-	},
-	error: {
-		fontSize: 17,
-		paddingBottom: 17,
-		textAlign: 'center'
 	}
 });
 
-// Inject the Navigation Hook as a prop to mimic the legacy behavior
-const HomeScreenWithNavigation = observer((props) => {
-	const stores = useStores();
-	const translation = useTranslation();
-
-	return (
-		<HomeScreen
-			{...props}
-			navigation={useNavigation()}
-			route={useRoute()}
-			{...stores}
-			{...translation}
-		/>
-	);
-});
-
-export default HomeScreenWithNavigation;
+export default HomeScreen;

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -8,6 +8,7 @@ import { Alert, AsyncStorage, Platform, SectionList, StyleSheet, View } from 're
 import { colors, Text } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import { action } from 'mobx';
 import { observer } from 'mobx-react';
 import { useTranslation } from 'react-i18next';
 
@@ -42,7 +43,7 @@ const SettingsScreen = observer(() => {
 				{ text: t('common.cancel') },
 				{
 					text: t('alerts.deleteServer.confirm'),
-					onPress: () => {
+					onPress: action(() => {
 						// Remove server and update active server
 						rootStore.serverStore.removeServer(index);
 						rootStore.settingStore.activeServer = 0;
@@ -54,17 +55,17 @@ const SettingsScreen = observer(() => {
 							// No servers are present, navigate to add server screen
 							navigation.replace('AddServer');
 						}
-					},
+					}),
 					style: 'destructive'
 				}
 			]
 		);
 	};
 
-	const onSelectServer = index => {
+	const onSelectServer = action(index => {
 		rootStore.settingStore.activeServer = index;
 		navigation.navigate('Home');
-	};
+	});
 
 	const onResetApplication = () => {
 		Alert.alert(
@@ -74,13 +75,13 @@ const SettingsScreen = observer(() => {
 				{ text: t('common.cancel') },
 				{
 					text: t('alerts.resetApplication.confirm'),
-					onPress: () => {
+					onPress: action(() => {
 						// Reset data in stores
 						rootStore.reset();
 						AsyncStorage.clear();
 						// Navigate to the loading screen
 						navigation.replace('AddServer');
-					},
+					}),
 					style: 'destructive'
 				}
 			]
@@ -121,13 +122,13 @@ const SettingsScreen = observer(() => {
 						key: 'keep-awake-switch',
 						title: t('settings.keepAwake'),
 						value: rootStore.settingStore.isScreenLockEnabled,
-						onValueChange: value => rootStore.settingStore.isScreenLockEnabled = value
+						onValueChange: action(value => rootStore.settingStore.isScreenLockEnabled = value)
 					},
 					{
 						key: 'rotation-lock-switch',
 						title: t('settings.rotationLock'),
 						value: rootStore.settingStore.isRotationEnabled,
-						onValueChange: value => rootStore.settingStore.isRotationEnabled = value
+						onValueChange: action(value => rootStore.settingStore.isRotationEnabled = value)
 					}
 				],
 				renderItem: SwitchListItem

--- a/stores/RootStore.js
+++ b/stores/RootStore.js
@@ -3,24 +3,40 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { decorate } from 'mobx';
+import { decorate, observable } from 'mobx';
 import { ignore } from 'mobx-sync';
 
 import ServerStore from './ServerStore';
 import SettingStore from './SettingStore';
 
 export default class RootStore {
+	/**
+	 * Has the store been loaded from storage
+	 */
 	storeLoaded = false
+
+	/**
+	 * Is the fullscreen interface active
+	 */
+	isFullscreen = false
 
 	serverStore = new ServerStore()
 	settingStore = new SettingStore()
 
 	reset() {
+		this.isFullscreen = false;
+
 		this.serverStore.reset();
 		this.settingStore.reset();
+
+		this.storeLoaded = true;
 	}
 }
 
 decorate(RootStore, {
-	storeLoaded: ignore
+	storeLoaded: ignore,
+	isFullscreen: [
+		ignore,
+		observable
+	]
 });


### PR DESCRIPTION
* Refactor HomeScreen into multiple components
* Moves logic for managing rotation lock state and hiding the status bar to App component
* Adds `action()` calls to functions that modify mobx state: https://mobx.js.org/refguide/action.html
* Adds `isFullscreen` to root mobx store
* Fixes buginess with pull to refresh (especially for Android)

This ended up being larger than expected and didn't even address the issue I started out looking at. :speak_no_evil: 

Fixes #9 