### PR TITLE
Fix book player by allowing about:srcdoc

### DIFF
--- a/components/NativeShellWebView.js
+++ b/components/NativeShellWebView.js
@@ -96,6 +96,8 @@ const NativeShellWebView = observer(React.forwardRef(
 		return (
 			<RefreshWebView
 				ref={ref}
+				// Allow any origin blocking can break various things like book playback
+				originWhitelist={['*']}
 				source={{ uri: server.urlString }}
 				// Inject javascript for NativeShell
 				// This method is preferred, but only supported on iOS currently


### PR DESCRIPTION
It turns out the ebook reader was blocked because it wasn't using http/https as the protocol for some aspect of it's operation. This allows any protocol which is the approach used in the Android app currently.

On a side note, I'm not sure where to stick this since 1.2.0 has been tagged, but not published yet. Do we proceed with 1.2.1? :joy: 