### PR TITLE
Fix extra bottom padding when not in fullscreen

### DIFF
--- a/screens/ErrorScreen.js
+++ b/screens/ErrorScreen.js
@@ -20,7 +20,7 @@ const ErrorScreen = () =>{
 	const route = useRoute();
 	const { icon, heading, message, details, buttonIcon, buttonTitle } = route.params;
 
-	const safeAreaEdges = ['right', 'bottom', 'left'];
+	const safeAreaEdges = ['right', 'left'];
 	if (Platform.OS !== 'ios') {
 		safeAreaEdges.push('top');
 	}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -68,9 +68,13 @@ const HomeScreen = observer(() => {
 	}, [httpErrorStatus]);
 
 	// When not in fullscreen, the top adjustment is handled by the spacer View for iOS
-	const safeAreaEdges = ['right', 'bottom', 'left'];
+	const safeAreaEdges = ['right', 'left'];
 	if (Platform.OS !== 'ios' || rootStore.isFullscreen) {
 		safeAreaEdges.push('top');
+	}
+	// Bottom spacer is handled by tab bar except in fullscreen
+	if (rootStore.isFullscreen) {
+		safeAreaEdges.push('bottom');
 	}
 	// Hide webview until loaded
 	const webviewStyle = (isLoading || httpErrorStatus) ? StyleSheet.compose(styles.container, styles.loading) : styles.container;

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -165,7 +165,7 @@ const SettingsScreen = observer(() => {
 	};
 
 	return (
-		<SafeAreaView style={styles.container} edges={['right', 'bottom', 'left']} >
+		<SafeAreaView style={styles.container} edges={['right', 'left']} >
 			<SectionList
 				sections={getSections()}
 				extraData={{


### PR DESCRIPTION
This should fix an issue where extra padding was being added to the bottom of screens. This padding should **only** be needed when in fullscreen playback since the tab bar includes proper spacing.