### PR TITLE
Fix crash on iOS 10 due to call stack size

### DIFF
--- a/components/ServerInput.js
+++ b/components/ServerInput.js
@@ -3,13 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { ActivityIndicator, Platform, StyleSheet } from 'react-native';
 import { Input, colors } from 'react-native-elements';
 import { useNavigation } from '@react-navigation/native';
+import { useTranslation } from 'react-i18next';
 import { action } from 'mobx';
 import { observer } from 'mobx-react';
-import PropTypes from 'prop-types';
 
 import { useStores } from '../hooks/useStores';
 import Colors from '../constants/Colors';
@@ -18,30 +18,22 @@ import JellyfinValidator from '../utils/JellyfinValidator';
 
 const sanitizeHost = (url = '') => url.trim();
 
-const ServerInput = observer(class ServerInput extends React.Component {
-	static propTypes = {
-		navigation: PropTypes.object.isRequired,
-		rootStore: PropTypes.object.isRequired,
-		t: PropTypes.func.isRequired,
-		onSuccess: PropTypes.func
-	}
+const ServerInput = observer(({ onSuccess, ...props }) => {
+	const [ host, setHost ] = useState('');
+	const [ isValidating, setIsValidating ] = useState(false);
+	const [ isValid, setIsValid ] = useState(true);
+	const [ validationMessage, setValidationMessage ] = useState('');
 
-	state = {
-		host: '',
-		isValidating: false,
-		isValid: true,
-		validationMessage: ''
-	}
+	const { rootStore } = useStores();
+	const navigation = useNavigation();
+	const { t } = useTranslation();
 
-	onAddServer = action(async () => {
-		const { host } = this.state;
+	const onAddServer = action(async () => {
 		console.log('add server', host);
 		if (host) {
-			this.setState({
-				isValidating: true,
-				isValid: true,
-				validationMessage: ''
-			});
+			setIsValidating(true);
+			setIsValid(true);
+			setValidationMessage('');
 
 			// Parse the entered url
 			let url;
@@ -50,11 +42,9 @@ const ServerInput = observer(class ServerInput extends React.Component {
 				console.log('parsed url', url);
 			} catch (err) {
 				console.info(err);
-				this.setState({
-					isValidating: false,
-					isValid: false,
-					validationMessage: this.props.t('addServer.validation.invalid')
-				});
+				setIsValidating(false);
+				setIsValid(false);
+				setValidationMessage(t('addServer.validation.invalid'));
 				return;
 			}
 
@@ -63,70 +53,64 @@ const ServerInput = observer(class ServerInput extends React.Component {
 			console.log(`Server is ${validation.isValid ? '' : 'not '}valid`);
 			if (!validation.isValid) {
 				const message = validation.message || 'invalid';
-				this.setState({
-					isValidating: false,
-					isValid: validation.isValid,
-					validationMessage: this.props.t([`addServer.validation.${message}`, 'addServer.validation.invalid'])
-				});
+				setIsValidating(false);
+				setIsValid(validation.isValid);
+				setValidationMessage(t([`addServer.validation.${message}`, 'addServer.validation.invalid']));
 				return;
 			}
 
 			// Save the server details
-			this.props.rootStore.serverStore.addServer({ url });
-			this.props.rootStore.settingStore.activeServer = this.props.rootStore.serverStore.servers.length - 1;
+			rootStore.serverStore.addServer({ url });
+			rootStore.settingStore.activeServer = rootStore.serverStore.servers.length - 1;
 			// Call the success callback if present
-			if (this.props.onSuccess) {
-				this.props.onSuccess();
+			if (onSuccess) {
+				onSuccess();
 			}
 			// Navigate to the main screen
-			this.props.navigation.replace(
+			navigation.replace(
 				'Main',
 				{
 					screen: 'Home',
 					params: {
 						screen: 'HomeScreen',
-						params: { activeServer: this.props.rootStore.settingStore.activeServer }
+						params: { activeServer: rootStore.settingStore.activeServer }
 					}
 				}
 			);
 		} else {
-			this.setState({
-				isValid: false,
-				validationMessage: this.props.t('addServer.validation.empty')
-			});
+			setIsValid(false);
+			setValidationMessage(t('addServer.validation.empty'));
 		}
-	})
+	});
 
-	render() {
-		return (
-			<Input
-				inputContainerStyle={styles.inputContainerStyle}
-				leftIcon={{
-					name: getIconName('globe'),
-					type: 'ionicon'
-				}}
-				labelStyle={{
-					color: colors.grey4
-				}}
-				placeholderTextColor={colors.grey3}
-				rightIcon={this.state.isValidating ? <ActivityIndicator /> : null}
-				selectionColor={Colors.tintColor}
-				autoCapitalize='none'
-				autoCorrect={false}
-				autoCompleteType='off'
-				autoFocus={true}
-				keyboardType={Platform.OS === 'ios' ? 'url' : 'default'}
-				returnKeyType='go'
-				textContentType='URL'
-				editable={!this.state.isValidating}
-				value={this.state.host}
-				errorMessage={this.state.isValid ? null : this.state.validationMessage}
-				onChangeText={text => this.setState({ host: sanitizeHost(text) })}
-				onSubmitEditing={() => this.onAddServer()}
-				{...this.props}
-			/>
-		);
-	}
+	return (
+		<Input
+			inputContainerStyle={styles.inputContainerStyle}
+			leftIcon={{
+				name: getIconName('globe'),
+				type: 'ionicon'
+			}}
+			labelStyle={{
+				color: colors.grey4
+			}}
+			placeholderTextColor={colors.grey3}
+			rightIcon={isValidating ? <ActivityIndicator /> : null}
+			selectionColor={Colors.tintColor}
+			autoCapitalize='none'
+			autoCorrect={false}
+			autoCompleteType='off'
+			autoFocus={true}
+			keyboardType={Platform.OS === 'ios' ? 'url' : 'default'}
+			returnKeyType='go'
+			textContentType='URL'
+			editable={!isValidating}
+			value={host}
+			errorMessage={isValid ? null : validationMessage}
+			onChangeText={text => setHost(sanitizeHost(text))}
+			onSubmitEditing={() => onAddServer()}
+			{...props}
+		/>
+	);
 });
 
 const styles = StyleSheet.create({
@@ -138,10 +122,4 @@ const styles = StyleSheet.create({
 	}
 });
 
-// Inject the Navigation Hook as a prop to mimic the legacy behavior
-const ServerInputWithNavigation = observer((props) => {
-	const stores = useStores();
-	return <ServerInput {...props} navigation={useNavigation()} {...stores} />;
-});
-
-export default ServerInputWithNavigation;
+export default ServerInput;

--- a/screens/AddServerScreen.js
+++ b/screens/AddServerScreen.js
@@ -35,7 +35,6 @@ const AddServerScreen = () => {
 				<ServerInput
 					label={t('addServer.address')}
 					placeholder='https://jellyfin.org'
-					t={t}
 				/>
 			</SafeAreaView>
 		</KeyboardAvoidingView>


### PR DESCRIPTION
It seems that somehow passing props through a wrapped component was causing a crash from within the react-native-elements library. Converting this element to be functional instead of class based seems to fix it. :crossed_fingers: 