### PR TITLE
Fix resetting rotation lock setting and update name to be accurate

### DIFF
--- a/App.js
+++ b/App.js
@@ -6,7 +6,7 @@
 import 'mobx-react-lite/batchingForReactNative';
 
 import React, { useEffect, useState } from 'react';
-import { AsyncStorage, Platform } from 'react-native';
+import { AsyncStorage } from 'react-native';
 import { ThemeProvider } from 'react-native-elements';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { observer } from 'mobx-react';

--- a/App.js
+++ b/App.js
@@ -58,11 +58,6 @@ const App = observer(({ skipLoadingScreen }) => {
 		}
 
 		rootStore.storeLoaded = true;
-
-		if (typeof rootStore.settingStore.isRotationEnabled === 'undefined') {
-			rootStore.settingStore.isRotationEnabled = Platform.OS === 'ios' && !Platform.isPad;
-			console.info('Initializing rotation lock setting', rootStore.settingStore.isRotationEnabled);
-		}
 	};
 
 	useEffect(() => {
@@ -71,16 +66,16 @@ const App = observer(({ skipLoadingScreen }) => {
 	}, []);
 
 	useEffect(() => {
-		console.info('rotation lock setting changed!', rootStore.settingStore.isRotationEnabled);
-		if (rootStore.settingStore.isRotationEnabled) {
+		console.info('rotation lock setting changed!', rootStore.settingStore.isRotationLockEnabled);
+		if (rootStore.settingStore.isRotationLockEnabled) {
 			ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
 		} else {
 			ScreenOrientation.unlockAsync();
 		}
-	}, [rootStore.settingStore.isRotationEnabled]);
+	}, [rootStore.settingStore.isRotationLockEnabled]);
 
 	const updateScreenOrientation = async () => {
-		if (rootStore.settingStore.isRotationEnabled) {
+		if (rootStore.settingStore.isRotationLockEnabled) {
 			if (rootStore.isFullscreen) {
 				// Lock to landscape orientation
 				// For some reason video apps on iPhone use LANDSCAPE_RIGHT ¯\_(ツ)_/¯

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -113,8 +113,8 @@ const SettingsScreen = observer(() => {
 			settingsData.push({
 				key: 'rotation-lock-switch',
 				title: t('settings.rotationLock'),
-				value: rootStore.settingStore.isRotationEnabled,
-				onValueChange: action(value => rootStore.settingStore.isRotationEnabled = value)
+				value: rootStore.settingStore.isRotationLockEnabled,
+				onValueChange: action(value => rootStore.settingStore.isRotationLockEnabled = value)
 			});
 		}
 

--- a/stores/SettingStore.js
+++ b/stores/SettingStore.js
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 import { action, decorate, observable } from 'mobx';
+import { Platform } from 'react-native';
 
 /**
  * Data store for application settings
@@ -15,9 +16,9 @@ export default class SettingStore {
 	activeServer = 0
 
 	/**
-	 * Is device rotation enabled
+	 * Is device rotation lock enabled
 	 */
-	isRotationEnabled
+	isRotationLockEnabled = Platform.OS === 'ios' && !Platform.isPad
 
 	/**
 	 * Is screen lock active when media is playing
@@ -26,14 +27,14 @@ export default class SettingStore {
 
 	reset() {
 		this.activeServer = 0;
-		this.isRotationEnabled = null;
+		this.isRotationLockEnabled = Platform.OS === 'ios' && !Platform.isPad;
 		this.isScreenLockEnabled = true;
 	}
 }
 
 decorate(SettingStore, {
 	activeServer: observable,
-	isRotationEnabled: observable,
+	isRotationLockEnabled: observable,
 	isScreenLockEnabled: observable,
 	reset: action
 });


### PR DESCRIPTION
* Fixes an issue where resetting the rotation lock setting would cause it to default to being disabled on iPhones since we set the value to `null` which made the `typeof` check [here](https://github.com/jellyfin/jellyfin-expo/blob/master/App.js#L62) fail.
* Fixes an issue where after resetting the app, rotation lock would be disabled on iPhones until the app was restarted since the initialization code only ran on the initial launch of the app.
* Moves the rotation lock initialization to the data store which is where it probably always should have been.
* Renames the name of the setting to be more accurate (`isRotationLockEnabled` vs `isRotationEnabled`).