### PR TITLE
Restore AC3/EAC3 for Dolby audio remuxing

### DIFF
--- a/utils/NativeShell.js
+++ b/utils/NativeShell.js
@@ -77,19 +77,35 @@ window.NativeShell = {
       return 'mobile';
     },
 
-    getDeviceProfile: function(profileBuilder) {
+    getDeviceProfile: function(profileBuilder, profileBuilderVersion) {
+      const audioCodecs = ['opus'];
+      const versionNumber = profileBuilderVersion !== undefined && profileBuilderVersion.split('.').map(num => Number.parseInt(num, 10));
+      const isAc3Eac3Disabled = profileBuilderVersion === undefined || (versionNumber.length === 3 && versionNumber[0] === 10 && versionNumber[1] < 7);
+      if (isAc3Eac3Disabled) {
+          audioCodecs.push('ac3');
+          audioCodecs.push('eac3');
+      }
+
       postExpoEvent('AppHost.getDeviceProfile');
       return profileBuilder({
         enableMkvProgressive: false,
-        disableHlsVideoAudioCodecs: ['opus']
+        disableHlsVideoAudioCodecs: audioCodecs
       });
     },
 
-    getSyncProfile: function(profileBuilder) {
+    getSyncProfile: function(profileBuilder, profileBuilderVersion) {
+      const audioCodecs = ['opus'];
+      const versionNumber = profileBuilderVersion !== undefined && profileBuilderVersion.split('.').map(num => Number.parseInt(num, 10));
+      const isAc3Eac3Disabled = profileBuilderVersion === undefined || (versionNumber.length === 3 && versionNumber[0] === 10 && versionNumber[1] < 7);
+      if (isAc3Eac3Disabled) {
+          audioCodecs.push('ac3');
+          audioCodecs.push('eac3');
+      }
+
       postExpoEvent('AppHost.getSyncProfile');
       return profileBuilder({
         enableMkvProgressive: false,
-        disableHlsVideoAudioCodecs: ['opus']
+        disableHlsVideoAudioCodecs: audioCodecs
       });
     },
 

--- a/utils/NativeShell.js
+++ b/utils/NativeShell.js
@@ -81,7 +81,7 @@ window.NativeShell = {
       postExpoEvent('AppHost.getDeviceProfile');
       return profileBuilder({
         enableMkvProgressive: false,
-        disableHlsVideoAudioCodecs: ['ac3', 'eac3', 'opus']
+        disableHlsVideoAudioCodecs: ['opus']
       });
     },
 
@@ -89,7 +89,7 @@ window.NativeShell = {
       postExpoEvent('AppHost.getSyncProfile');
       return profileBuilder({
         enableMkvProgressive: false,
-        disableHlsVideoAudioCodecs: ['ac3', 'eac3', 'opus']
+        disableHlsVideoAudioCodecs: ['opus']
       });
     },
 


### PR DESCRIPTION
**Changes**
- Restore AC3/EAC3 for Dolby audio remuxing.
- Related issue #142 should be resolved in https://github.com/jellyfin/jellyfin-web/pull/2135

**Issues**
DD/DD+ audios are forced transcoding to AAC on supported devices.
