### PR TITLE
Fix crash in sync profile for older server versions

### DIFF
--- a/utils/NativeShell.js
+++ b/utils/NativeShell.js
@@ -93,20 +93,10 @@ window.NativeShell = {
       });
     },
 
-    getSyncProfile: function(profileBuilder, profileBuilderVersion) {
-      const audioCodecs = ['opus'];
-      const versionNumber = profileBuilderVersion !== undefined && profileBuilderVersion.split('.').map(num => Number.parseInt(num, 10));
-      const isAc3Eac3Disabled = profileBuilderVersion === undefined || (versionNumber.length === 3 && versionNumber[0] === 10 && versionNumber[1] < 7);
-      if (isAc3Eac3Disabled) {
-          audioCodecs.push('ac3');
-          audioCodecs.push('eac3');
-      }
-
+    // Keep for support server versions < 10.7
+    getSyncProfile: function() {
       postExpoEvent('AppHost.getSyncProfile');
-      return profileBuilder({
-        enableMkvProgressive: false,
-        disableHlsVideoAudioCodecs: audioCodecs
-      });
+      return Promise.resolve({});
     },
 
     supports: function(command) {


### PR DESCRIPTION
The app was crashing because server versions < 10.7 call `getSyncProfile` with an options object as the second parameter. This method has been removed in 10.7 and was never supported in Jellyfin, so I changed it to just return a Promise resolving to an empty object.