### PR TITLE
Add missing lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "eject": "expo eject",
+    "lint": "eslint \".\"",
     "test": "node ./node_modules/jest/bin/jest.js --watchAll"
   },
   "jest": {


### PR DESCRIPTION
The lint action is trying to call a "lint" script that didn't exist so the action fails.