### PR TITLE
Add VSCode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ npm-debug.*
 *.p12
 *.key
 *.mobileprovision
-.vscode
 .yarn
 .pnp.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.staticjs": "javascript"
+    }
+}


### PR DESCRIPTION
Right now this only specifies the language used for the `.staticjs` files, but could be used to recommend plugins also.