### PR TITLE
Refactor themes

### DIFF
--- a/App.js
+++ b/App.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import { useStores } from './hooks/useStores';
 import Colors from './constants/Colors';
 import AppNavigator from './navigation/AppNavigator';
-import Theme from './utils/Theme';
+import DarkTheme from './themes/dark';
 import NativeShellLoader from './utils/NativeShellLoader';
 
 // Import i18n configuration
@@ -106,7 +106,7 @@ const App = observer(({ skipLoadingScreen }) => {
 
 	return (
 		<SafeAreaProvider>
-			<ThemeProvider theme={Theme}>
+			<ThemeProvider theme={DarkTheme.Elements}>
 				<StatusBar
 					style="light"
 					backgroundColor={Colors.headerBackgroundColor}

--- a/App.js
+++ b/App.js
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { AsyncStorage } from 'react-native';
-import { ThemeProvider } from 'react-native-elements';
+import { ThemeContext, ThemeProvider } from 'react-native-elements';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { observer } from 'mobx-react';
 import { AsyncTrunk } from 'mobx-sync';
@@ -18,7 +18,6 @@ import { Ionicons } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 
 import { useStores } from './hooks/useStores';
-import Colors from './constants/Colors';
 import AppNavigator from './navigation/AppNavigator';
 import DarkTheme from './themes/dark';
 import NativeShellLoader from './utils/NativeShellLoader';
@@ -29,6 +28,7 @@ import './i18n';
 const App = observer(({ skipLoadingScreen }) => {
 	const [isSplashReady, setIsSplashReady] = useState(false);
 	const { rootStore } = useStores();
+	const { theme } = useContext(ThemeContext);
 
 	const trunk = new AsyncTrunk(rootStore, {
 		storage: AsyncStorage
@@ -109,7 +109,7 @@ const App = observer(({ skipLoadingScreen }) => {
 			<ThemeProvider theme={DarkTheme.Elements}>
 				<StatusBar
 					style="light"
-					backgroundColor={Colors.headerBackgroundColor}
+					backgroundColor={theme.colors.grey0}
 					hidden={rootStore.isFullscreen}
 				/>
 				<AppNavigator />

--- a/components/ErrorView.js
+++ b/components/ErrorView.js
@@ -3,12 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { StyleSheet, View, useWindowDimensions } from 'react-native';
-import { Button, Text, Icon } from 'react-native-elements';
+import { Button, Icon, Text, ThemeContext } from 'react-native-elements';
 import PropTypes from 'prop-types';
 
-import Colors from '../constants/Colors';
 import { getIconName } from '../utils/Icons';
 
 const ErrorView = ({
@@ -23,9 +22,13 @@ const ErrorView = ({
 	const window = useWindowDimensions();
 	const isCompact = window.height < 480;
 	const marginVertical = isCompact ? 20 : 40;
+	const { theme } = useContext(ThemeContext);
 
 	return (
-		<View style={styles.container}>
+		<View style={{
+			...styles.container,
+			backgroundColor: theme.colors.background
+		}}>
 			<View style={styles.body}>
 				<Icon
 					name={icon.name}
@@ -72,8 +75,7 @@ const styles = StyleSheet.create({
 	container: {
 		...StyleSheet.absoluteFill,
 		flex: 1,
-		paddingHorizontal: 15,
-		backgroundColor: Colors.blackish
+		paddingHorizontal: 15
 	},
 	body: {
 		flexGrow: 1,

--- a/components/ErrorView.js
+++ b/components/ErrorView.js
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 		...StyleSheet.absoluteFill,
 		flex: 1,
 		paddingHorizontal: 15,
-		backgroundColor: Colors.backgroundColor
+		backgroundColor: Colors.blackish
 	},
 	body: {
 		flexGrow: 1,

--- a/components/ServerInput.js
+++ b/components/ServerInput.js
@@ -3,16 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { ActivityIndicator, Platform, StyleSheet } from 'react-native';
-import { Input, colors } from 'react-native-elements';
+import { Input, ThemeContext } from 'react-native-elements';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import { action } from 'mobx';
 import { observer } from 'mobx-react';
 
 import { useStores } from '../hooks/useStores';
-import Colors from '../constants/Colors';
 import { getIconName } from '../utils/Icons';
 import { parseUrl, validateServer } from '../utils/ServerValidator';
 
@@ -27,6 +26,7 @@ const ServerInput = observer(({ onSuccess, ...props }) => {
 	const { rootStore } = useStores();
 	const navigation = useNavigation();
 	const { t } = useTranslation();
+	const { theme } = useContext(ThemeContext);
 
 	const onAddServer = action(async () => {
 		console.log('add server', host);
@@ -92,11 +92,11 @@ const ServerInput = observer(({ onSuccess, ...props }) => {
 			}}
 			leftIconContainerStyle={styles.leftIconContainerStyle}
 			labelStyle={{
-				color: colors.grey4
+				color: theme.colors.grey4
 			}}
-			placeholderTextColor={colors.grey3}
+			placeholderTextColor={theme.colors.grey3}
 			rightIcon={isValidating ? <ActivityIndicator /> : null}
-			selectionColor={Colors.tintColor}
+			selectionColor={theme.colors.primary}
 			autoCapitalize='none'
 			autoCorrect={false}
 			autoCompleteType='off'

--- a/constants/Colors.js
+++ b/constants/Colors.js
@@ -3,24 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-const backgroundColor = '#101010';
-const textColor = '#fff';
-const primaryBlue = '#00a4dc';
-const primaryPurple = '#AA5CC3';
-
 export default {
-	primaryBlue,
-	primaryPurple,
-	textColor,
-	backgroundColor,
-	headerBackgroundColor: '#202020',
-	tintColor: primaryBlue,
-	headerTintColor: textColor,
-	tabText: '#ccc',
-	errorBackground: 'red',
-	errorText: textColor,
-	warningBackground: '#EAEB5E',
-	warningText: '#666804',
-	noticeBackground: primaryBlue,
-	noticeText: textColor
+	blue: '#00A4DC',
+	purple: '#AA5CC3',
+	white: '#FFF',
+	blackish: '#101010',
+	grey0: '#202020',
+	grey1: '#CCC'
 };

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -6,7 +6,6 @@
 import React, { useEffect } from 'react';
 import {
 	NavigationContainer,
-	DarkTheme,
 	getFocusedRouteNameFromRoute,
 	useNavigation
 } from '@react-navigation/native';
@@ -24,19 +23,7 @@ import ErrorScreen from '../screens/ErrorScreen';
 import HomeScreen from '../screens/HomeScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import { getIconName } from '../utils/Icons';
-
-// Customize theme for navigator
-const theme = {
-	...DarkTheme,
-	colors: {
-		...DarkTheme.colors,
-		primary: Colors.tintColor,
-		background: Colors.backgroundColor,
-		card: Colors.headerBackgroundColor,
-		text: Colors.textColor,
-		border: 'transparent'
-	}
-};
+import DarkTheme from '../themes/dark';
 
 const RootStack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -128,7 +115,7 @@ const AppNavigator = observer(() => {
 	SplashScreen.hideAsync();
 
 	return (
-		<NavigationContainer theme={theme}>
+		<NavigationContainer theme={DarkTheme.Navigation}>
 			<RootStack.Navigator
 				initialRouteName={(rootStore.serverStore.servers?.length > 0) ? 'Main' : 'AddServer'}
 				headerMode='screen'

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -3,7 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
+import { ThemeContext } from 'react-native-elements';
 import {
 	NavigationContainer,
 	getFocusedRouteNameFromRoute,
@@ -17,7 +18,6 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 
 import { useStores } from '../hooks/useStores';
-import Colors from '../constants/Colors';
 import AddServerScreen from '../screens/AddServerScreen';
 import ErrorScreen from '../screens/ErrorScreen';
 import HomeScreen from '../screens/HomeScreen';
@@ -79,6 +79,7 @@ const Home = observer(() => {
 
 const Main = observer(() => {
 	const { t } = useTranslation();
+	const { theme } = useContext(ThemeContext);
 
 	return (
 		<Tab.Navigator
@@ -86,7 +87,7 @@ const Main = observer(() => {
 				tabBarIcon: ({ color, size }) => TabIcon(route.name, color, size)
 			})}
 			tabBarOptions={{
-				inactiveTintColor: Colors.tabText
+				inactiveTintColor: theme.colors.grey1
 			}}
 		>
 			<Tab.Screen

--- a/screens/AddServerScreen.js
+++ b/screens/AddServerScreen.js
@@ -44,7 +44,7 @@ const AddServerScreen = () => {
 const styles = StyleSheet.create({
 	screen: {
 		flex: 1,
-		backgroundColor: Colors.backgroundColor
+		backgroundColor: Colors.blackish
 	},
 	container: {
 		flex: 1,

--- a/screens/AddServerScreen.js
+++ b/screens/AddServerScreen.js
@@ -3,22 +3,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { Image, KeyboardAvoidingView, Platform, StyleSheet, View } from 'react-native';
+import { ThemeContext } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useHeaderHeight } from '@react-navigation/stack';
 import { useTranslation } from 'react-i18next';
 
 import ServerInput from '../components/ServerInput';
-import Colors from '../constants/Colors';
 
 const AddServerScreen = () => {
 	const { t } = useTranslation();
 	const headerHeight = useHeaderHeight();
+	const { theme } = useContext(ThemeContext);
 
 	return (
 		<KeyboardAvoidingView
-			style={styles.screen}
+			style={{
+				...styles.screen,
+				backgroundColor: theme.colors.background
+			}}
 			behavior={Platform.OS == 'ios' ? 'padding' : 'height'}
 		>
 			<SafeAreaView
@@ -43,8 +47,7 @@ const AddServerScreen = () => {
 
 const styles = StyleSheet.create({
 	screen: {
-		flex: 1,
-		backgroundColor: Colors.blackish
+		flex: 1
 	},
 	container: {
 		flex: 1,

--- a/screens/ErrorScreen.js
+++ b/screens/ErrorScreen.js
@@ -11,7 +11,6 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useNavigation, useRoute } from '@react-navigation/native';
 
 import ErrorView from '../components/ErrorView';
-import Colors from '../constants/Colors';
 
 const ErrorScreen = () =>{
 	const [isRefreshing, setIsRefreshing] = useState(false);
@@ -29,7 +28,14 @@ const ErrorScreen = () =>{
 	}
 
 	return (
-		<SafeAreaView style={styles.container} edges={safeAreaEdges} mode='margin' >
+		<SafeAreaView
+			style={{
+				...styles.container,
+				backgroundColor: theme.colors.background
+			}}
+			edges={safeAreaEdges}
+			mode='margin'
+		>
 			{Platform.OS === 'ios' && (
 				<View style={{
 					...styles.statusBarSpacer,
@@ -59,7 +65,7 @@ const ErrorScreen = () =>{
 						backgroundColor={theme.colors.grey0}
 						// Android colors
 						colors={[theme.colors.primary, theme.colors.secondary]}
-						progressBackgroundColor={Colors.blackish}
+						progressBackgroundColor={theme.colors.background}
 					/>
 				}
 			>
@@ -79,8 +85,7 @@ const ErrorScreen = () =>{
 
 const styles = StyleSheet.create({
 	container: {
-		flex: 1,
-		backgroundColor: Colors.blackish
+		flex: 1
 	},
 	statusBarSpacer: {
 <<<<<<< HEAD

--- a/screens/ErrorScreen.js
+++ b/screens/ErrorScreen.js
@@ -38,7 +38,6 @@ const ErrorScreen = () =>{
 		>
 			{Platform.OS === 'ios' && (
 				<View style={{
-					...styles.statusBarSpacer,
 					backgroundColor: theme.colors.grey0,
 					height: insets.top
 				}} />
@@ -86,13 +85,6 @@ const ErrorScreen = () =>{
 const styles = StyleSheet.create({
 	container: {
 		flex: 1
-	},
-	statusBarSpacer: {
-<<<<<<< HEAD
-		backgroundColor: Colors.headerBackgroundColor
-=======
-		height: Constants.statusBarHeight
->>>>>>> Remove direct color references
 	}
 });
 

--- a/screens/ErrorScreen.js
+++ b/screens/ErrorScreen.js
@@ -3,8 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { Platform, RefreshControl, StyleSheet, View } from 'react-native';
+import { ThemeContext } from 'react-native-elements';
 import { ScrollView } from 'react-native-gesture-handler';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
@@ -14,6 +15,7 @@ import Colors from '../constants/Colors';
 
 const ErrorScreen = () =>{
 	const [isRefreshing, setIsRefreshing] = useState(false);
+	const { theme } = useContext(ThemeContext);
 
 	const insets = useSafeAreaInsets();
 
@@ -31,6 +33,7 @@ const ErrorScreen = () =>{
 			{Platform.OS === 'ios' && (
 				<View style={{
 					...styles.statusBarSpacer,
+					backgroundColor: theme.colors.grey0,
 					height: insets.top
 				}} />
 			)}
@@ -52,11 +55,11 @@ const ErrorScreen = () =>{
 						}}
 						enabled={true}
 						// iOS colors
-						tintColor={Colors.tabText}
-						backgroundColor={Colors.headerBackgroundColor}
+						tintColor={theme.colors.grey1}
+						backgroundColor={theme.colors.grey0}
 						// Android colors
-						colors={[Colors.primaryBlue, Colors.primaryPurple]}
-						progressBackgroundColor={Colors.backgroundColor}
+						colors={[theme.colors.primary, theme.colors.secondary]}
+						progressBackgroundColor={Colors.blackish}
 					/>
 				}
 			>
@@ -77,10 +80,14 @@ const ErrorScreen = () =>{
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: Colors.backgroundColor
+		backgroundColor: Colors.blackish
 	},
 	statusBarSpacer: {
+<<<<<<< HEAD
 		backgroundColor: Colors.headerBackgroundColor
+=======
+		height: Constants.statusBarHeight
+>>>>>>> Remove direct color references
 	}
 });
 

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -14,7 +14,6 @@ import { observer } from 'mobx-react';
 import { useStores } from '../hooks/useStores';
 import NativeShellWebView from '../components/NativeShellWebView';
 import ErrorView from '../components/ErrorView';
-import Colors from '../constants/Colors';
 import { getIconName } from '../utils/Icons';
 
 const HomeScreen = observer(() => {
@@ -87,7 +86,13 @@ const HomeScreen = observer(() => {
 	const server = rootStore.serverStore.servers[rootStore.settingStore.activeServer];
 
 	return (
-		<SafeAreaView style={styles.container} edges={safeAreaEdges} >
+		<SafeAreaView
+			style={{
+				...styles.container,
+				backgroundColor: theme.colors.background
+			}}
+			edges={safeAreaEdges}
+		>
 			{Platform.OS === 'ios' && !rootStore.isFullscreen && (
 				<View style={{
 					backgroundColor: theme.colors.grey0,
@@ -105,7 +110,7 @@ const HomeScreen = observer(() => {
 						backgroundColor: theme.colors.grey0,
 						// Android colors
 						colors: [theme.colors.primary, theme.colors.secondary],
-						progressBackgroundColor: Colors.blackish
+						progressBackgroundColor: theme.colors.background
 					}}
 					// Error screen is displayed if loading fails
 					renderError={errorCode => (
@@ -159,8 +164,7 @@ const HomeScreen = observer(() => {
 
 const styles = StyleSheet.create({
 	container: {
-		flex: 1,
-		backgroundColor: Colors.blackish
+		flex: 1
 	},
 	loading: {
 		opacity: 0

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -3,9 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useContext, useEffect, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Platform, StyleSheet, View } from 'react-native';
+import { ThemeContext } from 'react-native-elements';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { observer } from 'mobx-react';
@@ -21,6 +22,7 @@ const HomeScreen = observer(() => {
 	const navigation = useNavigation();
 	const { t } = useTranslation();
 	const insets = useSafeAreaInsets();
+	const { theme } = useContext(ThemeContext);
 
 	const [isLoading, setIsLoading] = useState(true);
 	const [httpErrorStatus, setHttpErrorStatus] = useState(null);
@@ -88,7 +90,7 @@ const HomeScreen = observer(() => {
 		<SafeAreaView style={styles.container} edges={safeAreaEdges} >
 			{Platform.OS === 'ios' && !rootStore.isFullscreen && (
 				<View style={{
-					...styles.statusBarSpacer,
+					backgroundColor: theme.colors.grey0,
 					height: insets.top
 				}} />
 			)}
@@ -99,11 +101,11 @@ const HomeScreen = observer(() => {
 					containerStyle={webviewStyle}
 					refreshControlProps={{
 						// iOS colors
-						tintColor: Colors.tabText,
-						backgroundColor: Colors.headerBackgroundColor,
+						tintColor: theme.colors.grey1,
+						backgroundColor: theme.colors.grey0,
 						// Android colors
-						colors: [Colors.primaryBlue, Colors.primaryPurple],
-						progressBackgroundColor: Colors.backgroundColor
+						colors: [theme.colors.primary, theme.colors.secondary],
+						progressBackgroundColor: Colors.blackish
 					}}
 					// Error screen is displayed if loading fails
 					renderError={errorCode => (
@@ -158,13 +160,10 @@ const HomeScreen = observer(() => {
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: Colors.backgroundColor
+		backgroundColor: Colors.blackish
 	},
 	loading: {
 		opacity: 0
-	},
-	statusBarSpacer: {
-		backgroundColor: Colors.headerBackgroundColor
 	}
 });
 

--- a/screens/LoadingScreen.js
+++ b/screens/LoadingScreen.js
@@ -12,7 +12,7 @@ import Colors from '../constants/Colors';
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: Colors.backgroundColor
+		backgroundColor: Colors.blackish
 	},
 	splash: {
 		flex: 1,

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Alert, AsyncStorage, Platform, SectionList, StyleSheet, View } from 'react-native';
-import { colors, Text } from 'react-native-elements';
+import { Text, ThemeContext } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { action } from 'mobx';
@@ -17,7 +17,6 @@ import BrowserListItem from '../components/BrowserListItem';
 import ButtonListItem from '../components/ButtonListItem';
 import ServerListItem from '../components/ServerListItem';
 import SwitchListItem from '../components/SwitchListItem';
-import Colors from '../constants/Colors';
 import Links from '../constants/Links';
 import { useStores } from '../hooks/useStores';
 
@@ -25,6 +24,7 @@ const SettingsScreen = observer(() => {
 	const { rootStore } = useStores();
 	const navigation = useNavigation();
 	const { t } = useTranslation();
+	const { theme } = useContext(ThemeContext);
 
 	useEffect(() => {
 		// Fetch server info
@@ -155,7 +155,7 @@ const SettingsScreen = observer(() => {
 					key: 'reset-app-button',
 					title: t('alerts.resetApplication.title'),
 					titleStyle: {
-						color: Platform.OS === 'ios' ? colors.platform.ios.error : colors.platform.android.error
+						color: theme.colors.error
 					},
 					onPress: onResetApplication
 				}],
@@ -165,7 +165,13 @@ const SettingsScreen = observer(() => {
 	};
 
 	return (
-		<SafeAreaView style={styles.container} edges={['right', 'left']} >
+		<SafeAreaView
+			style={{
+				...styles.container,
+				backgroundColor: theme.colors.background
+			}}
+			edges={['right', 'left']}
+		>
 			<SectionList
 				sections={getSections()}
 				extraData={{
@@ -174,7 +180,13 @@ const SettingsScreen = observer(() => {
 				}}
 				renderItem={({ item }) => <Text>{JSON.stringify(item)}</Text>}
 				renderSectionHeader={({ section: { title, hideHeader } }) => (
-					hideHeader ? <View style={styles.emptyHeader} /> : <Text style={styles.header}>{title}</Text>
+					hideHeader ?
+						<View style={styles.emptyHeader} /> :
+						<Text style={{
+							...styles.header,
+							backgroundColor: theme.colors.background,
+							color: theme.colors.grey4
+						}}>{title}</Text>
 				)}
 				renderSectionFooter={() => <View style={styles.footer} />}
 				ListFooterComponent={AppInfoFooter}
@@ -186,12 +198,9 @@ const SettingsScreen = observer(() => {
 
 const styles = StyleSheet.create({
 	container: {
-		flex: 1,
-		backgroundColor: Colors.blackish
+		flex: 1
 	},
 	header: {
-		backgroundColor: Colors.blackish,
-		color: colors.grey4,
 		fontSize: 17,
 		fontWeight: '600',
 		paddingVertical: 8,

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -187,10 +187,10 @@ const SettingsScreen = observer(() => {
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: Colors.backgroundColor
+		backgroundColor: Colors.blackish
 	},
 	header: {
-		backgroundColor: Colors.backgroundColor,
+		backgroundColor: Colors.blackish,
 		color: colors.grey4,
 		fontSize: 17,
 		fontWeight: '600',

--- a/themes/base/elements.js
+++ b/themes/base/elements.js
@@ -41,7 +41,7 @@ export default {
 	Overlay: {
 		windowBackgroundColor: 'rgba(0, 0, 0, .85)',
 		overlayStyle: {
-			backgroundColor: Colors.backgroundColor
+			backgroundColor: Colors.blackish
 		}
 	}
 };

--- a/themes/base/elements.js
+++ b/themes/base/elements.js
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 import { colors } from 'react-native-elements';
 
-import Colors from '../constants/Colors';
+import Colors from '../../constants/Colors';
 
 export default {
 	colors: {
@@ -14,10 +14,7 @@ export default {
 		...Platform.select({
 			default: colors.platform.android,
 			ios: colors.platform.ios
-		}),
-		primary: Colors.tintColor,
-		black: Colors.textColor,
-		white: Colors.headerBackgroundColor
+		})
 	},
 	Badge: {
 		badgeStyle: {

--- a/themes/dark/elements.js
+++ b/themes/dark/elements.js
@@ -10,8 +10,11 @@ export default {
 	...BaseTheme,
 	colors: {
 		...BaseTheme.colors,
-		primary: Colors.tintColor,
-		black: Colors.textColor,
-		white: Colors.headerBackgroundColor
+		primary: Colors.blue,
+		secondary: Colors.purple,
+		black: Colors.white,
+		white: Colors.grey0,
+		grey0: Colors.grey0,
+		grey1: Colors.grey1
 	}
 };

--- a/themes/dark/elements.js
+++ b/themes/dark/elements.js
@@ -1,0 +1,17 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import BaseTheme from '../base/elements';
+import Colors from '../../constants/Colors';
+
+export default {
+	...BaseTheme,
+	colors: {
+		...BaseTheme.colors,
+		primary: Colors.tintColor,
+		black: Colors.textColor,
+		white: Colors.headerBackgroundColor
+	}
+};

--- a/themes/dark/elements.js
+++ b/themes/dark/elements.js
@@ -10,6 +10,7 @@ export default {
 	...BaseTheme,
 	colors: {
 		...BaseTheme.colors,
+		background: Colors.blackish,
 		primary: Colors.blue,
 		secondary: Colors.purple,
 		black: Colors.white,

--- a/themes/dark/index.js
+++ b/themes/dark/index.js
@@ -1,0 +1,13 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import Elements from './elements';
+import Navigation from './navigation';
+
+export default {
+	dark: true,
+	Elements,
+	Navigation
+};

--- a/themes/dark/navigation.js
+++ b/themes/dark/navigation.js
@@ -1,0 +1,20 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { DarkTheme } from '@react-navigation/native';
+
+import Colors from '../../constants/Colors';
+
+export default {
+	...DarkTheme,
+	colors: {
+		...DarkTheme.colors,
+		primary: Colors.tintColor,
+		background: Colors.backgroundColor,
+		card: Colors.headerBackgroundColor,
+		text: Colors.textColor,
+		border: 'transparent'
+	}
+};

--- a/themes/dark/navigation.js
+++ b/themes/dark/navigation.js
@@ -11,10 +11,10 @@ export default {
 	...DarkTheme,
 	colors: {
 		...DarkTheme.colors,
-		primary: Colors.tintColor,
-		background: Colors.backgroundColor,
-		card: Colors.headerBackgroundColor,
-		text: Colors.textColor,
+		primary: Colors.blue,
+		background: Colors.blackish,
+		card: Colors.grey0,
+		text: Colors.white,
 		border: 'transparent'
 	}
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,3 @@
-/**
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 {
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+{
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "jsx": "react-native",
+        "lib": ["dom", "esnext"],
+        "moduleResolution": "node",
+        "noEmit": true,
+        "skipLibCheck": true,
+        "typeRoots": [
+            "./types"
+        ]
+    }
+}

--- a/types/react-native-elements.d.ts
+++ b/types/react-native-elements.d.ts
@@ -6,6 +6,7 @@
 /**
  * Extensions to the default react-native-elements types to allow for
  * custom properties in themes.
+ * Refs: https://reactnativeelements.com/docs/customization#typescript-definitions-extending-the-default-theme
  */
 type RecursivePartial<T> = { [P in keyof T]?: RecursivePartial<T[P]> };
 

--- a/types/react-native-elements.d.ts
+++ b/types/react-native-elements.d.ts
@@ -1,0 +1,20 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/**
+ * Extensions to the default react-native-elements types to allow for
+ * custom properties in themes.
+ */
+type RecursivePartial<T> = { [P in keyof T]?: RecursivePartial<T[P]> };
+
+declare module 'react-native-elements' {
+	export interface Colors {
+		background: string;
+	}
+
+	export interface FullTheme {
+		colors: RecursivePartial<Colors>;
+	}
+}

--- a/utils/WebBrowser.js
+++ b/utils/WebBrowser.js
@@ -9,8 +9,8 @@ import Colors from '../constants/Colors';
 
 export async function openBrowser(url, options) {
 	const finalOptions = Object.assign({
-		toolbarColor: Colors.backgroundColor,
-		controlsColor: Colors.tintColor
+		toolbarColor: Colors.blackish,
+		controlsColor: Colors.blue
 	}, options);
 
 	try {


### PR DESCRIPTION
* Changes structure to allow for multiple in-app themes
* Adds support to react-native-elements theme structure for background colors
  * TypeScript changes based on:
    * https://docs.expo.io/guides/typescript/#configuring-the-typescript-compiler
    * https://reactnativeelements.com/docs/customization#typescript-definitions-extending-the-default-theme
* Moves all direct color references to theme references (except for splash screen and web browser)