### PR TITLE
Fix logo size on add server screen in landscape

### DIFF
--- a/screens/AddServerScreen.js
+++ b/screens/AddServerScreen.js
@@ -7,7 +7,6 @@ import React, { useContext } from 'react';
 import { Image, KeyboardAvoidingView, Platform, StyleSheet, View } from 'react-native';
 import { ThemeContext } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useHeaderHeight } from '@react-navigation/stack';
 import { useTranslation } from 'react-i18next';
 
 import { useStores } from '../hooks/useStores';
@@ -15,7 +14,6 @@ import ServerInput from '../components/ServerInput';
 
 const AddServerScreen = () => {
 	const { t } = useTranslation();
-	const headerHeight = useHeaderHeight();
 	const { rootStore } = useStores();
 	const { theme } = useContext(ThemeContext);
 
@@ -28,7 +26,7 @@ const AddServerScreen = () => {
 			behavior={Platform.OS == 'ios' ? 'padding' : 'height'}
 		>
 			<SafeAreaView
-				style={{...styles.container, paddingBottom: headerHeight}}
+				style={styles.container}
 				edges={['right', 'bottom', 'left']}
 			>
 				<View style={styles.logoContainer}>
@@ -60,14 +58,15 @@ const styles = StyleSheet.create({
 		justifyContent: 'space-evenly'
 	},
 	logoContainer: {
-		alignItems: 'center'
+		alignSelf: 'center',
+		paddingVertical: 10,
+		minHeight: '40%',
+		maxWidth: '90%'
 	},
 	logoImage: {
-		marginVertical: 10,
-		width: 481,
-		height: 151,
-		maxWidth: '90%',
-		resizeMode: 'contain'
+		flex: 1,
+		resizeMode: 'contain',
+		maxWidth: '100%'
 	}
 });
 

--- a/screens/AddServerScreen.js
+++ b/screens/AddServerScreen.js
@@ -60,7 +60,8 @@ const styles = StyleSheet.create({
 	logoContainer: {
 		alignSelf: 'center',
 		paddingVertical: 10,
-		minHeight: '40%',
+		height: '40%',
+		maxHeight: 151,
 		maxWidth: '90%'
 	},
 	logoImage: {


### PR DESCRIPTION
Fixes the oversized logo on the add server screen when in landscape orientation.

**Before:**
![B4C677CD-9FA5-467D-903A-A432C5F58D57](https://user-images.githubusercontent.com/3450688/106499377-8423bb80-648e-11eb-97e5-1a1be094714b.png)

**After:**
![9313580E-2179-467A-A821-1D72F3B0117D](https://user-images.githubusercontent.com/3450688/106499401-8ab23300-648e-11eb-9fb3-505c2510ffe2.png)
