### PR TITLE
Add eslint rule for quotes in jsx

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
     },
     "rules": {
         "react/prop-types": ["error"],
+        "jsx-quotes": ["error", "prefer-single"],
 
         "block-spacing": ["error"],
         "brace-style": ["error"],


### PR DESCRIPTION
This fixes an oversight in the eslint config where single quotes are required for strings but the same does not apply for jsx.

I fixed the component with issues in https://github.com/jellyfin/jellyfin-expo/pull/210 so this should probably not be merged until after that PR is in.