### PR TITLE
Add quote type rule to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ trim_trailing_whitespace = true
 
 [{*.js, .staticjs}]
 indent_style = tab
+quote_type = single
 
 [*.json]
 indent_style = space


### PR DESCRIPTION
This configuration helps VS Code use the correct quote type for any code it generates.