### PR TITLE
Use default commit format for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,3 @@ updates:
     interval: daily
     time: '00:00'
   open-pull-requests-limit: 10
-  commit-message:
-    prefix: actions
-    include: scope


### PR DESCRIPTION
Make dependabot use the default commit format instead of the prefixed format