### PR TITLE
Add check for server info before checking version

### DIFF
--- a/components/NativeShellWebView.js
+++ b/components/NativeShellWebView.js
@@ -24,7 +24,7 @@ const NativeShellWebView = observer(React.forwardRef(
 		const [ isRefreshing, setIsRefreshing ] = useState(false);
 
 		const server = rootStore.serverStore.servers[rootStore.settingStore.activeServer];
-		const isPluginSupported = compareVersions.compare(server.info?.Version, '10.7', '>=');
+		const isPluginSupported = !!server.info?.Version && compareVersions.compare(server.info.Version, '10.7', '>=');
 
 		const injectedJavaScript = `
 window.ExpoAppInfo = {


### PR DESCRIPTION
Fixes an issue where the server info is not available immediately after adding a server. The compare versions function throws an exception if it is provided `null` instead of a string.