### PR TITLE
Fix test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ios": "expo start --ios",
     "eject": "expo eject",
     "lint": "eslint \".\"",
-    "test": "node ./node_modules/jest/bin/jest.js --watchAll"
+    "test": "jest --watchAll"
   },
   "jest": {
     "preset": "jest-expo",


### PR DESCRIPTION
This fixes an issue where the test script was failing. The `jest` script was not located in the expected place since we are using [jest-expo](https://docs.expo.io/guides/testing-with-jest/).