### PR TITLE
Fix online status not updating on error

### DIFF
--- a/models/ServerModel.js
+++ b/models/ServerModel.js
@@ -48,6 +48,7 @@ export default class ServerModel {
 			}))
 			.catch((err) => {
 				console.warn(err);
+				this.online = false;
 			});
 	})
 }

--- a/models/__tests__/ServerModel.test.js
+++ b/models/__tests__/ServerModel.test.js
@@ -67,4 +67,19 @@ describe('ServerModel', () => {
 
 		expect(server.online).toBe(false);
 	});
+
+	it('should update the online status when fetchInfo fails', async() => {
+		const server = new ServerModel(
+			'testId',
+			Url.parse('https://foobar')
+		);
+
+		fetch.mockResponse(JSON.stringify({ ServerName: 'Test Server' }));
+		await server.fetchInfo();
+		expect(server.online).toBe(true);
+
+		fetch.mockResponse(JSON.stringify({ error: 'test' }), { status: 500 });
+		await server.fetchInfo();
+		expect(server.online).toBe(false);
+	});
 });


### PR DESCRIPTION
Updates the online status of servers when fetching info fails

Fixes #224 