### PR TITLE
Disable patch check in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,4 @@ coverage:
       default:
         threshold: 1%
         if_not_found: success # no commit found? still set a success
-    patch:
-      default:
-        threshold: 1%
-        if_not_found: success
+    patch: off


### PR DESCRIPTION
This rule doesn't work the way that we thought... It's requiring any code touched to match the coverage level of the project. These rules were based on the ones added to vue and they have since removed it there also.