### PR TITLE
Update import sorting lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,11 @@
         "react-native/no-color-literals": ["error"],
         "react-native/no-raw-text": ["error"],
 
+        "import/order": ["warn", {
+            "alphabetize": { "order": "asc", "caseInsensitive": true },
+            "newlines-between": "always-and-inside-groups"
+        }],
+
         "array-bracket-spacing": ["error", "always", { "objectsInArrays": false, "arraysInArrays": false }],
         "array-callback-return": ["error"],
         "arrow-spacing": ["error"],
@@ -70,7 +75,6 @@
         "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": false }],
         "radix": ["error"],
         "semi": ["error"],
-        "sort-imports": ["warn", { "ignoreCase": true, "memberSyntaxSortOrder": ["all", "multiple", "single", "none"], "allowSeparatedGroups": true }],
         "space-before-blocks": ["error"],
         "space-in-parens": ["error"],
         "space-infix-ops": ["error"],


### PR DESCRIPTION
This changes to using the import eslint plugin for sorting rules. This rule works in a way that I prefer in that the sorting is based on the dependency name/path instead of the name of the variable being imported.

Additional information can be found in the plugin docs: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md

Error level is set to warn until all issues are fixed.