### PR TITLE
Refactor AppNavigator and ServerInput

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,20 +3,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useContext, useEffect, useState } from 'react';
-import { AsyncStorage } from 'react-native';
-import { AppearanceProvider, useColorScheme } from 'react-native-appearance';
-import { ThemeContext, ThemeProvider } from 'react-native-elements';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { observer } from 'mobx-react';
-import { AsyncTrunk } from 'mobx-sync';
+import { Ionicons } from '@expo/vector-icons';
+import { NavigationContainer } from '@react-navigation/native';
 import { AppLoading } from 'expo';
 import { Asset } from 'expo-asset';
 import * as Font from 'expo-font';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import { StatusBar } from 'expo-status-bar';
-import { Ionicons } from '@expo/vector-icons';
+import { observer } from 'mobx-react';
+import { AsyncTrunk } from 'mobx-sync';
 import PropTypes from 'prop-types';
+import React, { useContext, useEffect, useState } from 'react';
+import { AsyncStorage } from 'react-native';
+import { AppearanceProvider, useColorScheme } from 'react-native-appearance';
+import { ThemeContext, ThemeProvider } from 'react-native-elements';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import ThemeSwitcher from './components/ThemeSwitcher';
 import { useStores } from './hooks/useStores';
@@ -117,7 +118,9 @@ const App = observer(({ skipLoadingScreen }) => {
 						backgroundColor={theme.colors.grey0}
 						hidden={rootStore.isFullscreen}
 					/>
-					<AppNavigator />
+					<NavigationContainer theme={rootStore.settingStore.theme.Navigation}>
+						<AppNavigator />
+					</NavigationContainer>
 				</ThemeProvider>
 			</SafeAreaProvider>
 		</AppearanceProvider>

--- a/components/ServerInput.js
+++ b/components/ServerInput.js
@@ -21,7 +21,10 @@ const sanitizeHost = (url = '') => url.trim();
 
 const ServerInput = observer(React.forwardRef(
 	// FIXME: eslint fails to parse the propTypes properly here
-	function ServerInput({ onSuccess = () => {}, ...props }, ref) { // eslint-disable-line react/prop-types
+	function ServerInput({
+		onSuccess = () => { /* noop */ }, // eslint-disable-line react/prop-types
+		...props
+	}, ref) {
 		const [ host, setHost ] = useState('');
 		const [ isValidating, setIsValidating ] = useState(false);
 		const [ isValid, setIsValid ] = useState(true);

--- a/components/ServerInput.js
+++ b/components/ServerInput.js
@@ -3,121 +3,130 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useContext, useState } from 'react';
-import { ActivityIndicator, Platform, StyleSheet } from 'react-native';
-import { Input, ThemeContext } from 'react-native-elements';
 import { useNavigation } from '@react-navigation/native';
-import { useTranslation } from 'react-i18next';
 import { action } from 'mobx';
 import { observer } from 'mobx-react';
+import PropTypes from 'prop-types';
+import React, { useContext, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ActivityIndicator, Platform, StyleSheet } from 'react-native';
+import { Input, ThemeContext } from 'react-native-elements';
 
-import { useStores } from '../hooks/useStores';
 import Screens from '../constants/Screens';
+import { useStores } from '../hooks/useStores';
 import { getIconName } from '../utils/Icons';
 import { parseUrl, validateServer } from '../utils/ServerValidator';
 
 const sanitizeHost = (url = '') => url.trim();
 
-const ServerInput = observer(({ onSuccess, ...props }) => {
-	const [ host, setHost ] = useState('');
-	const [ isValidating, setIsValidating ] = useState(false);
-	const [ isValid, setIsValid ] = useState(true);
-	const [ validationMessage, setValidationMessage ] = useState('');
+const ServerInput = observer(React.forwardRef(
+	// FIXME: eslint fails to parse the propTypes properly here
+	function ServerInput({ onSuccess, ...props }, ref) { // eslint-disable-line react/prop-types
+		const [ host, setHost ] = useState('');
+		const [ isValidating, setIsValidating ] = useState(false);
+		const [ isValid, setIsValid ] = useState(true);
+		const [ validationMessage, setValidationMessage ] = useState('');
 
-	const { rootStore } = useStores();
-	const navigation = useNavigation();
-	const { t } = useTranslation();
-	const { theme } = useContext(ThemeContext);
+		const { rootStore } = useStores();
+		const navigation = useNavigation();
+		const { t } = useTranslation();
+		const { theme } = useContext(ThemeContext);
 
-	const onAddServer = action(async () => {
-		console.log('add server', host);
-		if (host) {
-			setIsValidating(true);
-			setIsValid(true);
-			setValidationMessage('');
+		const onAddServer = action(async () => {
+			console.log('add server', host);
+			if (host) {
+				setIsValidating(true);
+				setIsValid(true);
+				setValidationMessage('');
 
-			// Parse the entered url
-			let url;
-			try {
-				url = parseUrl(host);
-				console.log('parsed url', url);
-			} catch (err) {
-				console.info(err);
-				setIsValidating(false);
-				setIsValid(false);
-				setValidationMessage(t('addServer.validation.invalid'));
-				return;
-			}
-
-			// Validate the server is available
-			const validation = await validateServer({ url });
-			console.log(`Server is ${validation.isValid ? '' : 'not '}valid`);
-			if (!validation.isValid) {
-				const message = validation.message || 'invalid';
-				setIsValidating(false);
-				setIsValid(validation.isValid);
-				setValidationMessage(t([ `addServer.validation.${message}`, 'addServer.validation.invalid' ]));
-				return;
-			}
-
-			// Save the server details
-			rootStore.serverStore.addServer({ url });
-			rootStore.settingStore.activeServer = rootStore.serverStore.servers.length - 1;
-			// Call the success callback if present
-			if (onSuccess) {
-				onSuccess();
-			}
-			// Navigate to the main screen
-			navigation.replace(
-				Screens.MainScreen,
-				{
-					screen: Screens.HomeTab,
-					params: {
-						screen: Screens.HomeScreen,
-						params: { activeServer: rootStore.settingStore.activeServer }
-					}
+				// Parse the entered url
+				let url;
+				try {
+					url = parseUrl(host);
+					console.log('parsed url', url);
+				} catch (err) {
+					console.info(err);
+					setIsValidating(false);
+					setIsValid(false);
+					setValidationMessage(t('addServer.validation.invalid'));
+					return;
 				}
-			);
-		} else {
-			setIsValid(false);
-			setValidationMessage(t('addServer.validation.empty'));
-		}
-	});
 
-	return (
-		<Input
-			inputContainerStyle={{
-				...styles.inputContainerStyle,
-				backgroundColor: theme.colors.searchBg
-			}}
-			leftIcon={{
-				name: getIconName('globe'),
-				type: 'ionicon',
-				color: theme.colors.grey3
-			}}
-			leftIconContainerStyle={styles.leftIconContainerStyle}
-			labelStyle={{
-				color: theme.colors.grey1
-			}}
-			placeholderTextColor={theme.colors.grey3}
-			rightIcon={isValidating ? <ActivityIndicator /> : null}
-			selectionColor={theme.colors.primary}
-			autoCapitalize='none'
-			autoCorrect={false}
-			autoCompleteType='off'
-			autoFocus={true}
-			keyboardType={Platform.OS === 'ios' ? 'url' : 'default'}
-			returnKeyType='go'
-			textContentType='URL'
-			editable={!isValidating}
-			value={host}
-			errorMessage={isValid ? null : validationMessage}
-			onChangeText={text => setHost(sanitizeHost(text))}
-			onSubmitEditing={() => onAddServer()}
-			{...props}
-		/>
-	);
-});
+				// Validate the server is available
+				const validation = await validateServer({ url });
+				console.log(`Server is ${validation.isValid ? '' : 'not '}valid`);
+				if (!validation.isValid) {
+					const message = validation.message || 'invalid';
+					setIsValidating(false);
+					setIsValid(validation.isValid);
+					setValidationMessage(t([ `addServer.validation.${message}`, 'addServer.validation.invalid' ]));
+					return;
+				}
+
+				// Save the server details
+				rootStore.serverStore.addServer({ url });
+				rootStore.settingStore.activeServer = rootStore.serverStore.servers.length - 1;
+				// Call the success callback if present
+				if (onSuccess) {
+					onSuccess();
+				}
+				// Navigate to the main screen
+				navigation.replace(
+					Screens.MainScreen,
+					{
+						screen: Screens.HomeTab,
+						params: {
+							screen: Screens.HomeScreen,
+							params: { activeServer: rootStore.settingStore.activeServer }
+						}
+					}
+				);
+			} else {
+				setIsValid(false);
+				setValidationMessage(t('addServer.validation.empty'));
+			}
+		});
+
+		return (
+			<Input
+				ref={ref}
+				inputContainerStyle={{
+					...styles.inputContainerStyle,
+					backgroundColor: theme.colors.searchBg
+				}}
+				leftIcon={{
+					name: getIconName('globe'),
+					type: 'ionicon',
+					color: theme.colors.grey3
+				}}
+				leftIconContainerStyle={styles.leftIconContainerStyle}
+				labelStyle={{
+					color: theme.colors.grey1
+				}}
+				placeholderTextColor={theme.colors.grey3}
+				rightIcon={isValidating ? <ActivityIndicator /> : null}
+				selectionColor={theme.colors.primary}
+				autoCapitalize='none'
+				autoCorrect={false}
+				autoCompleteType='off'
+				autoFocus={true}
+				keyboardType={Platform.OS === 'ios' ? 'url' : 'default'}
+				returnKeyType='go'
+				textContentType='URL'
+				editable={!isValidating}
+				value={host}
+				errorMessage={isValid ? null : validationMessage}
+				onChangeText={text => setHost(sanitizeHost(text))}
+				onSubmitEditing={() => onAddServer()}
+				{...props}
+			/>
+		);
+	}
+));
+
+ServerInput.propTypes = {
+	onSuccess: PropTypes.func
+};
 
 const styles = StyleSheet.create({
 	inputContainerStyle: {

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -3,22 +3,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import * as SplashScreen from 'expo-splash-screen';
-import {
-	getFocusedRouteNameFromRoute,
-	NavigationContainer
-} from '@react-navigation/native';
+import { getFocusedRouteNameFromRoute } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import * as SplashScreen from 'expo-splash-screen';
 import { observer } from 'mobx-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import AddServerScreen from '../screens/AddServerScreen';
 import Screens from '../constants/Screens';
-import TabNavigator from './TabNavigator';
 import { useStores } from '../hooks/useStores';
+import AddServerScreen from '../screens/AddServerScreen';
 
-const RootStack = createStackNavigator();
+import TabNavigator from './TabNavigator';
+
+const AppStack = createStackNavigator();
 
 const AppNavigator = observer(() => {
 	const { rootStore } = useStores();
@@ -28,38 +26,36 @@ const AppNavigator = observer(() => {
 	SplashScreen.hideAsync().catch(console.debug);
 
 	return (
-		<NavigationContainer theme={rootStore.settingStore.theme.Navigation}>
-			<RootStack.Navigator
-				initialRouteName={(rootStore.serverStore.servers?.length > 0) ? Screens.MainScreen : Screens.AddServerScreen}
-				headerMode='screen'
-				screenOptions={{ headerShown: false }}
-			>
-				<RootStack.Screen
-					name={Screens.MainScreen}
-					component={TabNavigator}
-					options={({ route }) => {
-						const routeName =
-							// Get the currently active route name in the tab navigator
-							getFocusedRouteNameFromRoute(route) ||
-							// If state doesn't exist, we need to default to `screen` param if available, or the initial screen
-							// In our case, it's "Main" as that's the first screen inside the navigator
-							route.params?.screen || Screens.MainScreen;
-						return ({
-							headerShown: routeName === Screens.SettingsTab,
-							title: t(`headings.${routeName.toLowerCase()}`)
-						});
-					}}
-				/>
-				<RootStack.Screen
-					name={Screens.AddServerScreen}
-					component={AddServerScreen}
-					options={{
-						headerShown: rootStore.serverStore.servers?.length > 0,
-						title: t('headings.addServer')
-					}}
-				/>
-			</RootStack.Navigator>
-		</NavigationContainer>
+		<AppStack.Navigator
+			initialRouteName={(rootStore.serverStore.servers?.length > 0) ? Screens.MainScreen : Screens.AddServerScreen}
+			headerMode='screen'
+			screenOptions={{ headerShown: false }}
+		>
+			<AppStack.Screen
+				name={Screens.MainScreen}
+				component={TabNavigator}
+				options={({ route }) => {
+					const routeName =
+						// Get the currently active route name in the tab navigator
+						getFocusedRouteNameFromRoute(route) ||
+						// If state doesn't exist, we need to default to `screen` param if available, or the initial screen
+						// In our case, it's "Main" as that's the first screen inside the navigator
+						route.params?.screen || Screens.MainScreen;
+					return ({
+						headerShown: routeName === Screens.SettingsTab,
+						title: t(`headings.${routeName.toLowerCase()}`)
+					});
+				}}
+			/>
+			<AppStack.Screen
+				name={Screens.AddServerScreen}
+				component={AddServerScreen}
+				options={{
+					headerShown: rootStore.serverStore.servers?.length > 0,
+					title: t('headings.addServer')
+				}}
+			/>
+		</AppStack.Navigator>
 	);
 });
 


### PR DESCRIPTION
Breaking this apart a bit so it will be easier to review. This really just includes some general refactoring.

* Fixes issues with import order
* Moves NavigationContainer to App component
* Renames Stack in AppNavigator to match other navigators
* Adds support for forwarding refs in ServerInput (needed to call functions on Input component in ServerInput)
* Adds missing prop type validation in ServerInput
* Reduces the cognitive complexity of ServerInput to appease SonarCloud

Best viewed with whitespace changes hidden: https://github.com/jellyfin/jellyfin-expo/pull/243/files?diff=unified&w=1