### PR TITLE
Fix native player crash in live tv

### DIFF
--- a/assets/js/plugins/NativeVideoPlayer.staticjs
+++ b/assets/js/plugins/NativeVideoPlayer.staticjs
@@ -111,6 +111,11 @@ class NativeVideoPlayer {
 		return this.positionMillis;
 	}
 
+	// Dummy method (required by web for live tv)
+	duration() {
+		return null;
+	}
+
 	// Dummy method (required by web)
 	isMuted() {
 		return false;


### PR DESCRIPTION
This fixes a crash in web when trying to use the native player for live tv... although playback still doesn't work for some reason. It maybe timing out somewhere?