### PR TITLE
Add recommended vscode extensions and licenser configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "orta.vscode-jest",
+        "ymotongpoo.licenser"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "files.associations": {
         "*.staticjs": "javascript"
-    }
+    },
+    "licenser.customHeader": "This Source Code Form is subject to the terms of the Mozilla Public\nLicense, v. 2.0. If a copy of the MPL was not distributed with this\nfile, You can obtain one at http://mozilla.org/MPL/2.0/.",
+    "licenser.license": "Custom",
+    "licenser.useSingleLineStyle": false
 }


### PR DESCRIPTION
This adds configuration for a few recommended VS Code extensions:
* eslint - for linting
* jest - for unit tests
* licenser - for inserting license headers

It also adds a configuration for the licenser extension that uses a "custom" header which is just the standard MPLv2 header without the author copyright preceding it.