### PR TITLE
Migrate Project to Jellyfin's Expo Organization

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "Jellyfin",
     "slug": "jellyfin-expo",
+    "owner": "jellyfin",
     "privacy": "unlisted",
     "platforms": [
       "ios",


### PR DESCRIPTION
Adds the owner tag to link the project together with the org.