### PR TITLE
Enable additional codec and container support for native player

### DIFF
--- a/utils/profiles/ios.js
+++ b/utils/profiles/ios.js
@@ -18,7 +18,13 @@ export default {
 			AudioCodec: 'aac,mp3,ac3,eac3,flac,alac',
 			Container: 'mp4,m4v',
 			Type: MediaTypes.Video,
-			VideoCodec: 'h264'
+			VideoCodec: 'hevc,h264'
+		},
+		{
+			AudioCodec: 'aac,mp3,ac3,eac3,flac,alac',
+			Container: 'mov',
+			Type: MediaTypes.Video,
+			VideoCodec: 'hevc,h264'
 		},
 		{
 			Container: 'mp3',

--- a/utils/profiles/ios10.js
+++ b/utils/profiles/ios10.js
@@ -56,6 +56,12 @@ export default {
 			VideoCodec: 'h264,vc1'
 		},
 		{
+			AudioCodec: 'aac,mp3,dca,dts,alac',
+			Container: 'mov',
+			Type: MediaTypes.Video,
+			VideoCodec: 'h264'
+		},
+		{
 			Container: 'mp3',
 			Type: MediaTypes.Audio
 		},


### PR DESCRIPTION
Enables direct playing hevc in iOS 11+ and mov in all profiles

hevc support reference: https://support.apple.com/en-us/HT207022