### PR TITLE
chore(ci): replace with actions-label-merge-conflict

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -1,18 +1,17 @@
-name: "Merge Conflicts"
+name: 'Merge Conflicts'
 
 on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     types:
       - synchronize
 jobs:
   triage:
     runs-on: ubuntu-latest
-    if: github.repository == 'jellyfin/jellyfin-expo'
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@master
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.1
         with:
-          CONFLICT_LABEL_NAME: "merge conflict"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dirtyLabel: 'merge conflict'
+          repoToken: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
I tested the query this action performs in GraphQL explorer and checked the source code and it should fit all our needs. It will label PRs with conflicts only, **without paying attention to the rest of the conditions (reviews, rebase, etc)**.

It's also maintained by its owner, while the original action had a PR from me (to add the exact behaviour we want) sitting for days so, in the long-term, this action should be a better solution.

Needs the ``GH_TOKEN`` added by @anthonylavado so the label is applied by jellyfin-bot instead of github-actions