### PR TITLE
Fix fMP4 version check

### DIFF
--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -3,24 +3,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { Alert, AsyncStorage, Platform, SectionList, StyleSheet, View } from 'react-native';
-import React, { useContext, useEffect } from 'react';
-import { Text, ThemeContext } from 'react-native-elements';
+import { useNavigation } from '@react-navigation/native';
+import compareVersions from 'compare-versions';
 import { action } from 'mobx';
 import { observer } from 'mobx-react';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import React, { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Alert, AsyncStorage, Platform, SectionList, StyleSheet, View } from 'react-native';
+import { Text, ThemeContext } from 'react-native-elements';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import AppInfoFooter from '../components/AppInfoFooter';
 import BrowserListItem from '../components/BrowserListItem';
 import ButtonListItem from '../components/ButtonListItem';
-import { isSystemThemeSupported } from '../utils/Device';
-import Links from '../constants/Links';
-import Screens from '../constants/Screens';
 import ServerListItem from '../components/ServerListItem';
 import SwitchListItem from '../components/SwitchListItem';
+import Links from '../constants/Links';
+import Screens from '../constants/Screens';
 import { useStores } from '../hooks/useStores';
+import { isSystemThemeSupported } from '../utils/Device';
 
 const SettingsScreen = observer(() => {
 	const { rootStore } = useStores();
@@ -135,7 +136,7 @@ const SettingsScreen = observer(() => {
 				})
 			});
 
-			if (Platform.Version > 12) {
+			if (compareVersions.compare(Platform.Version, '12', '>')) {
 				playbackSettingsData.push({
 					key: 'native-video-fmp4-switch',
 					title: t('settings.fmp4Support'),

--- a/stores/SettingStore.js
+++ b/stores/SettingStore.js
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import compareVersions from 'compare-versions';
 import { action, computed, decorate, observable } from 'mobx';
 import { Platform } from 'react-native';
 
@@ -25,7 +26,7 @@ export default class SettingStore {
 	/**
 	 * Is screen lock active when media is playing
 	 */
-	isScreenLockEnabled = Platform.OS === 'ios' ? (parseInt(Platform.Version, 10) < 14) : true
+	isScreenLockEnabled = Platform.OS === 'ios' ? !!Platform.Version && compareVersions.compare(Platform.Version, '14', '<') : true
 
 	/**
 	 * Are tab labels enabled
@@ -65,7 +66,7 @@ export default class SettingStore {
 	reset() {
 		this.activeServer = 0;
 		this.isRotationLockEnabled = Platform.OS === 'ios' && !Platform.isPad;
-		this.isScreenLockEnabled = Platform.OS === 'ios' ? (parseInt(Platform.Version, 10) < 14) : true;
+		this.isScreenLockEnabled = Platform.OS === 'ios' ? !!Platform.Version && compareVersions.compare(Platform.Version, '14', '<') : true;
 		this.isTabLabelsEnabled = true;
 		this.themeId = 'dark';
 		this.systemThemeId = null;

--- a/stores/SettingStore.js
+++ b/stores/SettingStore.js
@@ -8,11 +8,14 @@ import { action, computed, decorate, observable } from 'mobx';
 import { Platform } from 'react-native';
 
 import Themes from '../themes';
-
 /**
  * Data store for application settings
  */
 export default class SettingStore {
+	#DEFAULT_ROTATION_LOCK_ENABLED = Platform.OS === 'ios' && !Platform.isPad;
+
+	#DEFAULT_SCREEN_LOCK_ENABLED = Platform.OS === 'ios' ? !!Platform.Version && compareVersions.compare(Platform.Version, '14', '<') : true;
+
 	/**
 	 * The id of the currently selected server
 	 */
@@ -21,12 +24,12 @@ export default class SettingStore {
 	/**
 	 * Is device rotation lock enabled
 	 */
-	isRotationLockEnabled = Platform.OS === 'ios' && !Platform.isPad
+	isRotationLockEnabled = this.#DEFAULT_ROTATION_LOCK_ENABLED
 
 	/**
 	 * Is screen lock active when media is playing
 	 */
-	isScreenLockEnabled = Platform.OS === 'ios' ? !!Platform.Version && compareVersions.compare(Platform.Version, '14', '<') : true
+	isScreenLockEnabled = this.#DEFAULT_SCREEN_LOCK_ENABLED
 
 	/**
 	 * Are tab labels enabled
@@ -65,8 +68,8 @@ export default class SettingStore {
 
 	reset() {
 		this.activeServer = 0;
-		this.isRotationLockEnabled = Platform.OS === 'ios' && !Platform.isPad;
-		this.isScreenLockEnabled = Platform.OS === 'ios' ? !!Platform.Version && compareVersions.compare(Platform.Version, '14', '<') : true;
+		this.isRotationLockEnabled = this.#DEFAULT_ROTATION_LOCK_ENABLED;
+		this.isScreenLockEnabled = this.#DEFAULT_SCREEN_LOCK_ENABLED;
 		this.isTabLabelsEnabled = true;
 		this.themeId = 'dark';
 		this.systemThemeId = null;

--- a/utils/Device.js
+++ b/utils/Device.js
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import compareVersions from 'compare-versions';
 import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
@@ -33,9 +34,9 @@ export function getSafeDeviceName() {
 
 export function getDeviceProfile({ enableFmp4 = false } = {}) {
 	if (Platform.OS === 'ios') {
-		if (parseInt(Platform.Version, 10) < 11) {
+		if (compareVersions.compare(Platform.Version, '11', '<')) {
 			return iOS10Profile;
-		} else if (parseInt(Platform.Version, 10) < 13) {
+		} else if (compareVersions.compare(Platform.Version, '13', '<')) {
 			return iOS12Profile;
 		} else if (enableFmp4) {
 			return iOSFmp4Profile;
@@ -53,6 +54,6 @@ export function isCompact({ height = 500 } = {}) {
 
 // Does the platform support system level themes: https://docs.expo.io/versions/latest/sdk/appearance/
 export function isSystemThemeSupported() {
-	return (Platform.OS === 'ios' && parseInt(Platform.Version, 10) > 12) ||
-		(Platform.OS === 'android' && parseInt(Platform.Version, 10) > 9);
+	return (Platform.OS === 'ios' && compareVersions.compare(Platform.Version, '12', '>')) ||
+		(Platform.OS === 'android' && compareVersions.compare(Platform.Version, '9', '>'));
 }


### PR DESCRIPTION
This fixes an issue where the fMP4 playback option is unavailable on patch platform version numbers (i.e. 14.4 works, but not 14.4.2). I also migrated all platform version checks to use the compare-versions utility instead of just using parseInt.