### PR TITLE
Remove PR description enforcement action

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -15,12 +15,3 @@ jobs:
         with:
           dirtyLabel: 'merge conflict'
           repoToken: ${{ secrets.JF_BOT_TOKEN }}
-
-  enforce:
-    name: Enforce PR description
-    runs-on: ubuntu-latest
-    steps:
-      - uses: derkinderfietsen/pr-description-enforcer@v1
-        if: ${{ github.event_name == 'pull_request_target' }}
-        with:
-          repo-token: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
The action used for this seems to have been removed from GitHub so it is causing failures.