### PR TITLE
Update url handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,7 +88,12 @@
     "ignorePatterns": [ "coverage" ],
     "overrides": [
         {
-            "files": [ "./**/*.js" ]
+            "files": [ "./**/*.js" ],
+            "globals": {
+                "AbortController": "readonly",
+                "URL": "readonly",
+                "URLSearchParams": "readonly"
+            }
         },
         {
             "files": [ "./**/*.test.js" ],

--- a/App.js
+++ b/App.js
@@ -3,6 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
+// polyfill whatwg URL globals
+import 'react-native-url-polyfill/auto';
+
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';

--- a/models/__tests__/ServerModel.test.js
+++ b/models/__tests__/ServerModel.test.js
@@ -3,7 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import Url from 'url';
+
+import { URL } from 'url';
 
 import ServerModel from '../ServerModel';
 
@@ -16,7 +17,7 @@ describe('ServerModel', () => {
 	it('should create a ServerModel with computed properties', () => {
 		const server = new ServerModel(
 			'testId',
-			Url.parse('https://foobar'),
+			new URL('https://foobar'),
 			{
 				ServerName: 'Test Server'
 			}
@@ -31,7 +32,7 @@ describe('ServerModel', () => {
 	it('should fallback to the url if server name is unavailable', () => {
 		const server = new ServerModel(
 			'testId',
-			Url.parse('https://foobar')
+			new URL('https://foobar')
 		);
 
 		expect(server.name).toBe('foobar');
@@ -48,7 +49,7 @@ describe('ServerModel', () => {
 
 		const server = new ServerModel(
 			'testId',
-			Url.parse('https://foobar')
+			new URL('https://foobar')
 		);
 		await server.fetchInfo();
 
@@ -61,7 +62,7 @@ describe('ServerModel', () => {
 
 		const server = new ServerModel(
 			'testId',
-			Url.parse('https://foobar')
+			new URL('https://foobar')
 		);
 		await server.fetchInfo();
 
@@ -71,7 +72,7 @@ describe('ServerModel', () => {
 	it('should update the online status when fetchInfo fails', async () => {
 		const server = new ServerModel(
 			'testId',
-			Url.parse('https://foobar')
+			new URL('https://foobar')
 		);
 
 		fetch.mockResponse(JSON.stringify({ ServerName: 'Test Server' }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -6990,6 +6990,33 @@
       "integrity": "sha512-eCJcWn2OYFEIqbm70ta7LQowJOOZZqq1a2YbbFCFI1uwSvj+TWMwXVn7vPR1ceFNcAIt5RSTDbwdlX82gYLTkA==",
       "requires": {
         "normalize-url": "^2.0.1"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        }
       }
     },
     "compare-versions": {
@@ -12015,8 +12042,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -17809,31 +17835,9 @@
       }
     },
     "normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "query-string": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
-          }
-        },
-        "strict-uri-encode": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-        }
-      }
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.0.2.tgz",
+      "integrity": "sha512-HC9c6eHqxmiR6sL9DKt9ttLkiLaI1jytdkJMGAEvkLAAdlOi99kR7UMWWWRrwjucuFabaau4ZuvP1Zv+6PpDjA=="
     },
     "npm-bundled": {
       "version": "1.1.2",
@@ -19884,8 +19888,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -20819,6 +20822,14 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz",
       "integrity": "sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw=="
+    },
+    "react-native-url-polyfill": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
+      "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
+      "requires": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      }
     },
     "react-native-webview": {
       "version": "11.6.2",
@@ -25278,6 +25289,32 @@
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "requires": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "setupFilesAfterEnv": [
       "@testing-library/jest-native/extend-expect"
     ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|normalize-url)"
+    ],
     "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.{js,jsx}",
@@ -56,6 +59,7 @@
     "mobx-react": "^6.2.2",
     "mobx-sync": "^3.0.0",
     "mobx-task": "^2.0.1",
+    "normalize-url": "^7.0.2",
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-i18next": "^11.7.0",
@@ -68,6 +72,7 @@
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
+    "react-native-url-polyfill": "^1.3.0",
     "react-native-webview": "11.6.2",
     "uuid": "^8.3.2"
   },

--- a/stores/ServerStore.js
+++ b/stores/ServerStore.js
@@ -33,7 +33,7 @@ export default class ServerStore {
 
 decorate(ServerStore, {
 	servers: [
-		format(data => data.map(value => new ServerModel(value.id, value.url, value.info))),
+		format(data => data.map(value => new ServerModel(value.id, new URL(value.url), value.info))),
 		observable
 	],
 	addServer: action,

--- a/stores/ServerStore.js
+++ b/stores/ServerStore.js
@@ -33,7 +33,12 @@ export default class ServerStore {
 
 decorate(ServerStore, {
 	servers: [
-		format(data => data.map(value => new ServerModel(value.id, new URL(value.url), value.info))),
+		format(data => data.map(value => {
+			// Migrate from old url format
+			// TODO: Remove migration in next minor release
+			const url = value.url.href || value.url;
+			return new ServerModel(value.id, new URL(url), value.info);
+		})),
 		observable
 	],
 	addServer: action,

--- a/stores/__tests__/ServerStore.test.js
+++ b/stores/__tests__/ServerStore.test.js
@@ -3,7 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import Url from 'url';
+
+import { URL } from 'url';
 
 import ServerStore from '../ServerStore';
 
@@ -29,12 +30,12 @@ describe('ServerStore', () => {
 	});
 
 	it('should allow servers to be added', () => {
-		store.addServer({ url: Url.parse('https://foobar') });
+		store.addServer({ url: new URL('https://foobar') });
 		expect(store.servers).toHaveLength(1);
 		expect(store.servers[0].id).toBe(0);
 		expect(store.servers[0].url.host).toBe('foobar');
 
-		store.addServer({ url: Url.parse('https://baz') });
+		store.addServer({ url: new URL('https://baz') });
 		expect(store.servers).toHaveLength(2);
 	});
 
@@ -53,8 +54,8 @@ describe('ServerStore', () => {
 	});
 
 	it('should call fetchInfo for each server', () => {
-		store.addServer({ url: Url.parse('https://foobar') });
-		store.addServer({ url: Url.parse('https://baz') });
+		store.addServer({ url: new URL('https://foobar') });
+		store.addServer({ url: new URL('https://baz') });
 		store.fetchInfo();
 
 		expect(mockFetchInfo).toHaveBeenCalledTimes(2);

--- a/utils/ServerValidator.js
+++ b/utils/ServerValidator.js
@@ -13,14 +13,11 @@ export const parseUrl = (host = '', port = '') => {
 		throw new Error('host cannot be blank');
 	}
 
+	// Normalize the entered url
 	host = normalizeUrl(host, { stripWWW: false });
 
 	// Parse the host as a url
 	const url = new URL(host);
-
-	if (!url.hostname) {
-		throw new Error(`Could not parse hostname for ${host}`);
-	}
 
 	// Override the port if provided
 	if (port) {

--- a/utils/ServerValidator.js
+++ b/utils/ServerValidator.js
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-/* globals AbortController, URL */
 
 import normalizeUrl from 'normalize-url';
 

--- a/utils/ServerValidator.js
+++ b/utils/ServerValidator.js
@@ -3,24 +3,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-/* globals AbortController */
-import Url from 'url';
+/* globals AbortController, URL */
+
+import normalizeUrl from 'normalize-url';
 
 const TIMEOUT_DURATION = 5000; // timeout request after 5s
 
 export const parseUrl = (host = '', port = '') => {
-	if (!host) {
+	if (!host?.trim()) {
 		throw new Error('host cannot be blank');
 	}
 
-	// Default the protocol to http if not present
-	// Setting the protocol on the parsed url does not update the href
-	if (!host.startsWith('http://') && !host.startsWith('https://')) {
-		host = `http://${host}`;
-	}
+	host = normalizeUrl(host, { stripWWW: false });
 
 	// Parse the host as a url
-	const url = Url.parse(host);
+	const url = new URL(host);
 
 	if (!url.hostname) {
 		throw new Error(`Could not parse hostname for ${host}`);

--- a/utils/__tests__/ServerValidator.test.js
+++ b/utils/__tests__/ServerValidator.test.js
@@ -3,7 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import Url from 'url';
+
+import { URL } from 'url';
 
 import { fetchServerInfo, getServerUrl, parseUrl, validateServer } from '../ServerValidator';
 
@@ -16,10 +17,11 @@ describe('ServerValidator', () => {
 	describe('parseUrl()', () => {
 		it('should throw an error if called without host', () => {
 			expect(parseUrl).toThrow('host cannot be blank');
+			expect(() => parseUrl(' ')).toThrow('host cannot be blank');
 		});
 
 		it('should throw an error if hostname is invalid', () => {
-			expect(() => parseUrl(' ')).toThrow('Could not parse hostname for http:// ');
+			expect(() => parseUrl('/')).toThrow('Invalid URL: /');
 		});
 
 		it('should default to http protocol if not specified', () => {
@@ -32,7 +34,7 @@ describe('ServerValidator', () => {
 			const url = parseUrl('foobar', 8096);
 			expect(url.protocol).toBe('http:');
 			expect(url.hostname).toBe('foobar');
-			expect(url.port).toBe(8096);
+			expect(url.port).toBe('8096');
 		});
 
 		it('should use https protocol if specified', () => {
@@ -65,12 +67,12 @@ describe('ServerValidator', () => {
 		});
 
 		it('should strip search part from the server url', () => {
-			const server = { url: Url.parse('https://foobar/?search') };
+			const server = { url: new URL('https://foobar/?search') };
 			expect(getServerUrl(server)).toBe('https://foobar/');
 		});
 
 		it('should strip hash part from the server url', () => {
-			const server = { url: Url.parse('https://foobar/#hash') };
+			const server = { url: new URL('https://foobar/#hash') };
 			expect(getServerUrl(server)).toBe('https://foobar/');
 		});
 
@@ -80,7 +82,7 @@ describe('ServerValidator', () => {
 		});
 
 		it('should return the url if called with a valid server object', () => {
-			const server = { url: Url.parse('https://foobar/') };
+			const server = { url: new URL('https://foobar/') };
 			expect(getServerUrl(server)).toBe('https://foobar/');
 		});
 	});
@@ -95,21 +97,21 @@ describe('ServerValidator', () => {
 		it('should return valid for 10.2.x servers', async () => {
 			fetch.mockResponse(JSON.stringify({ Id: 'test', Version: '10.2.0' }));
 
-			const result = await validateServer({ url: Url.parse('https://foobar/') });
+			const result = await validateServer({ url: new URL('https://foobar/') });
 			expect(result.isValid).toBe(true);
 		});
 
 		it('should return valid if product name is "Jellyfin Server"', async () => {
 			fetch.mockResponse(JSON.stringify({ ProductName: 'Jellyfin Server' }));
 
-			const result = await validateServer({ url: Url.parse('https://foobar/') });
+			const result = await validateServer({ url: new URL('https://foobar/') });
 			expect(result.isValid).toBe(true);
 		});
 
 		it('should return invalidProduct message if product name is not "Jellyfin Server"', async () => {
 			fetch.mockResponse(JSON.stringify({ ProductName: 'test', Version: '3.5' }));
 
-			const result = await validateServer({ url: Url.parse('https://foobar/') });
+			const result = await validateServer({ url: new URL('https://foobar/') });
 			expect(result.isValid).toBe(false);
 			expect(result.message).toBe('invalidProduct');
 		});
@@ -117,7 +119,7 @@ describe('ServerValidator', () => {
 		it('should return noConnection message if fetch throws error', async () => {
 			fetch.mockResponse(JSON.stringify({ error: 'test' }), { status: 500 });
 
-			const result = await validateServer({ url: Url.parse('https://foobar/') });
+			const result = await validateServer({ url: new URL('https://foobar/') });
 			expect(result.isValid).toBe(false);
 			expect(result.message).toBe('noConnection');
 		});


### PR DESCRIPTION
Uses the `normalize-url` package for normalizing user entered urls and adds polyfill for standard URL globals that are not available in react-native. This mirrors the approach I have used in the TypeScript SDK.

Depends on #312 