### PR TITLE
Cleanup native video player

### DIFF
--- a/assets/js/plugins/NativeVideoPlayer.staticjs
+++ b/assets/js/plugins/NativeVideoPlayer.staticjs
@@ -5,7 +5,7 @@
  */
 
 class NativeVideoPlayer {
-	constructor({ appSettings, events, playbackManager, loading }) {
+	constructor({ events, playbackManager, loading }) {
 		// declare public fields because iOS < 14 does not support them properly
 		this.name = 'ExpoVideoPlayer';
 		this.type = 'mediaplayer';
@@ -14,11 +14,10 @@ class NativeVideoPlayer {
 		this.isLocalPlayer = true;
 
 		this.uri = null;
-		this.isPlaying = false;
+		this._isPlaying = false;
 		this.positionMillis = 0;
 
 		// local references to web classes
-		this.appSettings = appSettings;
 		this.events = events;
 		this.playbackManager = playbackManager;
 		this.loading = loading;
@@ -35,7 +34,7 @@ class NativeVideoPlayer {
 		this.mediaSource = null;
 
 		this.uri = null;
-		this.isPlaying = false;
+		this._isPlaying = false;
 		this.positionMillis = 0;
 	}
 
@@ -65,9 +64,9 @@ class NativeVideoPlayer {
 		}
 
 		// The playing state has changed
-		if (status.isPlaying !== this.isPlaying) {
-			this.isPlaying = status.isPlaying;
-			this._safelyTriggerEvent(this.isPlaying ? 'playing' : 'pause');
+		if (status.isPlaying !== this._isPlaying) {
+			this._isPlaying = status.isPlaying;
+			this._safelyTriggerEvent(this._isPlaying ? 'playing' : 'pause');
 		}
 
 		// The playback position has changed
@@ -121,9 +120,14 @@ class NativeVideoPlayer {
 		return false;
 	}
 
+	// Return the playing state (required by web)
+	isPlaying() {
+		return this._isPlaying;
+	}
+
 	// Return the paused state (required by web)
 	paused() {
-		return !this.isPlaying;
+		return !this._isPlaying;
 	}
 
 	// Called by web to begin playback

--- a/components/NativeShellWebView.js
+++ b/components/NativeShellWebView.js
@@ -55,6 +55,8 @@ ${StaticScriptLoader.scripts.NativeShell}
 
 ${StaticScriptLoader.scripts.ExpoRouterShim}
 
+window.onerror = console.error;
+
 true;
 `;
 

--- a/components/VideoPlayer.js
+++ b/components/VideoPlayer.js
@@ -44,7 +44,7 @@ const VideoPlayer = observer(() => {
 
 	// Update the play/pause state when the store indicates it should
 	useEffect(() => {
-		if (rootStore.mediaStore.shouldPlayPause) {
+		if (rootStore.mediaStore.type === MediaTypes.Video && rootStore.mediaStore.shouldPlayPause) {
 			if (rootStore.mediaStore.isPlaying) {
 				player.current?.pauseAsync();
 			} else {
@@ -56,7 +56,7 @@ const VideoPlayer = observer(() => {
 
 	// Close the player when the store indicates it should stop playback
 	useEffect(() => {
-		if (rootStore.mediaStore.shouldStop) {
+		if (rootStore.mediaStore.type === MediaTypes.Video && rootStore.mediaStore.shouldStop) {
 			rootStore.didPlayerCloseManually = false;
 			closeFullscreen();
 			rootStore.mediaStore.shouldStop = false;


### PR DESCRIPTION
* Adds additional error reporting from the webview for unhandled errors
* Removes unused `appSettings` from the native video player plugin
* Fixes an issue where `isPlaying` in the native video player needs to be a function not a property
* Limits the `VideoPlayer` component to only act on video media