### PR TITLE
Add eslint rule for empty functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,7 @@
         "keyword-spacing": ["error"],
         "max-statements-per-line": ["error"],
         "no-duplicate-imports": ["error"],
+        "no-empty-function": ["error"],
         "no-floating-decimal": ["error"],
         "no-multi-spaces": ["error"],
         "no-multiple-empty-lines": ["error", { "max": 1 }],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -20,7 +20,7 @@ jest.mock('react-native-reanimated', () => {
 
 	// The mock for `call` immediately calls the callback which is incorrect
 	// So we override it with a no-op
-	Reanimated.default.call = () => {};
+	Reanimated.default.call = () => { /* no-op */ };
 
 	return Reanimated;
 });


### PR DESCRIPTION
Sonarcube does not like empty functions, so I've updated eslint to also raise an error for them.