### PR TITLE
Fix question label name for stale action

### DIFF
--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -17,7 +17,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-close: 21
           days-before-pr-close: -1
-          any-of-labels: questions
+          any-of-labels: question
           stale-issue-label: stale
           stale-issue-message: |-
             This issue has gone 120 days without comment. To avoid abandoned issues, it will be closed in 21 days if there are no new comments.


### PR DESCRIPTION
The label name should be "question" not "questions". :wink: 