### PR TITLE
Remove exitmenu as a supported feature

### DIFF
--- a/assets/js/NativeShell.staticjs
+++ b/assets/js/NativeShell.staticjs
@@ -8,7 +8,6 @@
 const ExpoSupportedFeatures = [
 	// 'filedownload',
 	'exit',
-	'exitmenu',
 	'plugins',
 	'externallinks',
 	'externalpremium',


### PR DESCRIPTION
Removes the previously unused "exitmenu" feature support to prevent the new menu entry showing (and not working) in Jellyfin 10.8

Fixes #340 