### PR TITLE
Fix native-stack warning

### DIFF
--- a/navigation/RootNavigator.js
+++ b/navigation/RootNavigator.js
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 import { enableScreens } from 'react-native-screens';
-import { createNativeStackNavigator } from 'react-native-screens/native-stack';
 
 import Screens from '../constants/Screens';
 import ServerHelpScreen from '../screens/ServerHelpScreen';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3143,6 +3143,22 @@
         "nanoid": "^3.1.23"
       }
     },
+    "@react-navigation/native-stack": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.5.0.tgz",
+      "integrity": "sha512-X2sV+AKkqEl7k0ltjN4lMBfx+FsynrnUWkCTGiROyMRo4yWElK1jY3XSTsj5Cpso2/MUHdf9v/AOw0EgU58FsA==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.1",
+        "warn-once": "^0.1.0"
+      },
+      "dependencies": {
+        "@react-navigation/elements": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.1.tgz",
+          "integrity": "sha512-jIDRJaG8YPIinl4hZXJu/W3TnhDe8hLYmGSEdL1mxZ1aoNMiApCBYkgTy11oq0EfK/koZd3DPSkJNbzBAQmPJw=="
+        }
+      }
+    },
     "@react-navigation/routers": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "^6.0.7",
     "@react-navigation/native": "^6.0.4",
+    "@react-navigation/native-stack": "^6.5.0",
     "@react-navigation/stack": "^6.0.9",
     "compare-versions": "^3.6.0",
     "expo": "^43.0.0",


### PR DESCRIPTION
The native-stack dependency moved to a separate package, importing it in the old way was working, but produced a warning