### PR TITLE
Use filled icon for active tab

### DIFF
--- a/navigation/TabNavigator.js
+++ b/navigation/TabNavigator.js
@@ -19,16 +19,20 @@ import { getIconName } from '../utils/Icons';
 import HomeNavigator from './HomeNavigator';
 import SettingsNavigator from './SettingsNavigator';
 
-function TabIcon(routeName, color, size) {
+function TabIcon(routeName, focused, color, size) {
 	let iconName = null;
 	if (routeName === Screens.HomeTab) {
-		iconName = getIconName('tv-outline');
+		iconName = getIconName('tv');
 	} else if (routeName === Screens.DownloadsTab) {
-		iconName = 'download-outline';
+		iconName = 'download';
 	} else if (routeName === Screens.SettingsTab) {
-		iconName = getIconName('cog-outline');
+		iconName = getIconName('cog');
 	} else {
-		iconName = 'help-circle-outline';
+		iconName = 'help-circle';
+	}
+
+	if (!focused) {
+		iconName += '-outline';
 	}
 
 	return (
@@ -58,7 +62,7 @@ const TabNavigator = observer(() => {
 		<Tab.Navigator
 			screenOptions={({ route }) => ({
 				headerShown: false,
-				tabBarIcon: ({ color, size }) => TabIcon(route.name, color, size),
+				tabBarIcon: ({ focused, color, size }) => TabIcon(route.name, focused, color, size),
 				tabBarInactiveTintColor: theme.colors.grey1,
 				tabBarShowLabel: rootStore.settingStore.isTabLabelsEnabled,
 				tabBarStyle


### PR DESCRIPTION
A minor update to the styling of active tabs.

![3790C497-CD91-4FA2-8C27-94D060E14F94](https://user-images.githubusercontent.com/3450688/170809540-2ed946af-1258-4c9c-81fc-ada3e2781336.jpeg)

![FD63AACE-B9DA-49E9-866A-71A94743A4B2](https://user-images.githubusercontent.com/3450688/170809532-800d6289-544e-481e-8dc0-2e1614b25119.jpeg)
