### PR TITLE
Bump supported iOS version to 12+

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "browserslist": [
-    "iOS > 10",
+    "iOS > 11",
     "Android >= 5"
   ],
   "dependencies": {


### PR DESCRIPTION
Since we upgraded to Expo 43, we only support iOS 12+.