### PR TITLE
Don't require full screen on iOS

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,6 +29,7 @@
     "ios": {
       "buildNumber": "5.5.0.0",
       "supportsTablet": true,
+      "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",
       "infoPlist": {
         "UIBackgroundModes": [


### PR DESCRIPTION
fixes #426 
fixes #376

couldn't test it because the Expo Go app already supports split screen and couldn't figure out how to build the standalone app