### PR TITLE
Fix incorrect react-native version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11735,9 +11735,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-native": {
-      "version": "0.69.6",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.6.tgz",
-      "integrity": "sha512-wwXpqM+12kdEYdBZCJUb5SBu95CzgejrwFeYJ78RzHZV/Sj6DBRekbsHGrDDsY4R25QXALQxy4DQYQCObVvWjA==",
+      "version": "0.69.9",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.9.tgz",
+      "integrity": "sha512-I1xqIn47RWxBToO4E6yqyIPSaK9mZnMiscMfrFpWjQr3Gdkicr9y+twmtrRszxaLdQLjHzh/M3y4qOqc3hZnpg==",
       "requires": {
         "@jest/create-cache-key-function": "^27.0.1",
         "@react-native-community/cli": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "18.0.0",
     "react-i18next": "11.18.6",
     "react-lifecycles-compat": "3.0.4",
-    "react-native": "0.69.6",
+    "react-native": "0.69.9",
     "react-native-elements": "3.4.3",
     "react-native-gesture-handler": "~2.5.0",
     "react-native-get-random-values": "~1.8.0",

--- a/utils/__tests__/ServerValidator.test.js
+++ b/utils/__tests__/ServerValidator.test.js
@@ -21,7 +21,7 @@ describe('ServerValidator', () => {
 		});
 
 		it('should throw an error if hostname is invalid', () => {
-			expect(() => parseUrl('/')).toThrow('Invalid URL: /');
+			expect(() => parseUrl('/')).toThrow('Invalid URL');
 		});
 
 		it('should default to http protocol if not specified', () => {


### PR DESCRIPTION
Not sure how this happened, but we are using the wrong version of react-native for the current expo version

```
Some dependencies are incompatible with the installed expo version:
  react-native@0.69.6 - expected version: 0.69.9
Your project may not work correctly until you install the correct versions of the packages.
Install individual packages by running npx expo install react-native@0.69.9
```