### PR TITLE
Remove unavailable Expo version

### DIFF
--- a/components/AppInfoFooter.js
+++ b/components/AppInfoFooter.js
@@ -7,7 +7,6 @@
 import { useNavigation } from '@react-navigation/native';
 import Constants from 'expo-constants';
 import React, { useContext } from 'react';
-import { useTranslation } from 'react-i18next';
 import { StyleSheet, View } from 'react-native';
 import { Text, ThemeContext } from 'react-native-elements';
 
@@ -16,7 +15,6 @@ import { getAppName } from '../utils/Device';
 
 const AppInfoFooter = () => {
 	const navigation = useNavigation();
-	const { t } = useTranslation();
 	const { theme } = useContext(ThemeContext);
 
 	const textStyle = {
@@ -37,9 +35,6 @@ const AppInfoFooter = () => {
 			</Text>
 			<Text testID='app-version' style={textStyle}>
 				{`${Constants.nativeAppVersion} (${Constants.nativeBuildVersion})`}
-			</Text>
-			<Text testID='expo-version' style={textStyle}>
-				{t('settings.expoVersion', { version: Constants.expoVersion })}
 			</Text>
 		</View>
 	);

--- a/components/__tests__/AppInfoFooter.test.js
+++ b/components/__tests__/AppInfoFooter.test.js
@@ -29,7 +29,6 @@ jest.mock('@react-navigation/native', () => {
 
 describe('AppInfoFooter', () => {
 	it('should render correctly', () => {
-		Constants.expoVersion = '39.0.0';
 		Constants.nativeAppVersion = '1.0.0';
 		Constants.nativeBuildVersion = '1.0.0.0';
 		Device.osName = 'Test OS'; // eslint-disable-line no-import-assign, import/namespace
@@ -45,6 +44,5 @@ describe('AppInfoFooter', () => {
 		fireEvent(appName, 'onLongPress');
 		expect(mockNavigate).toHaveBeenCalledWith(Screens.DevSettingsScreen);
 		expect(getByTestId('app-version')).toHaveTextContent('1.0.0 (1.0.0.0)');
-		expect(getByTestId('expo-version')).toHaveTextContent('Expo Version: 39.0.0');
 	});
 });

--- a/langs/en.json
+++ b/langs/en.json
@@ -65,8 +65,7 @@
     "lightTheme": "Use Light Theme",
     "systemTheme": "Use System Theme",
     "rotationLock": "Rotation Lock",
-    "tabLabels": "Show Tab Labels",
-    "expoVersion": "Expo Version: {{version}}"
+    "tabLabels": "Show Tab Labels"
   },
   "links": {
     "website": "Jellyfin Website",

--- a/screens/__tests__/__snapshots__/SettingsScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/SettingsScreen.test.js.snap
@@ -720,17 +720,6 @@ exports[`SettingsScreen should render correctly 1`] = `
           >
             mock (mock)
           </Text>
-          <Text
-            style={
-              Object {
-                "color": "#43484d",
-                "fontSize": 15,
-              }
-            }
-            testID="expo-version"
-          >
-            Expo Version: mock
-          </Text>
         </View>
       </View>
     </View>


### PR DESCRIPTION
Removes the Expo version from the settings screen because it is not available now when building manually