### PR TITLE
Enable fmp4 by default for native player

### DIFF
--- a/stores/SettingStore.js
+++ b/stores/SettingStore.js
@@ -59,7 +59,7 @@ export default class SettingStore {
 	/**
 	 * Is fMP4 enabled for the native video player
 	 */
-	isFmp4Enabled = false;
+	isFmp4Enabled = true;
 
 	/**
 	 * EXPERIMENTAL: Is the native audio player enabled
@@ -85,7 +85,7 @@ export default class SettingStore {
 		this.systemThemeId = null;
 		this.isSystemThemeEnabled = false;
 		this.isNativeVideoPlayerEnabled = false;
-		this.isFmp4Enabled = false;
+		this.isFmp4Enabled = true;
 
 		this.isExperimentalNativeAudioPlayerEnabled = false;
 		this.isExperimentalDownloadsEnabled = false;

--- a/stores/__tests__/SettingStore.test.js
+++ b/stores/__tests__/SettingStore.test.js
@@ -27,7 +27,7 @@ describe('SettingStore', () => {
 		expect(store.isSystemThemeEnabled).toBe(false);
 		expect(store.theme).toBe(Themes.dark);
 		expect(store.isNativeVideoPlayerEnabled).toBe(false);
-		expect(store.isFmp4Enabled).toBe(false);
+		expect(store.isFmp4Enabled).toBe(true);
 		expect(store.isExperimentalDownloadsEnabled).toBe(false);
 	});
 
@@ -88,7 +88,7 @@ describe('SettingStore', () => {
 		store.systemThemeId = 'dark';
 		store.isSystemThemeEnabled = true;
 		store.isNativeVideoPlayerEnabled = true;
-		store.isFmp4Enabled = true;
+		store.isFmp4Enabled = false;
 		store.isExperimentalDownloadsEnabled = true;
 
 		expect(store.activeServer).toBe(99);
@@ -100,7 +100,7 @@ describe('SettingStore', () => {
 		expect(store.isSystemThemeEnabled).toBe(true);
 		expect(store.theme).toBe(Themes.dark);
 		expect(store.isNativeVideoPlayerEnabled).toBe(true);
-		expect(store.isFmp4Enabled).toBe(true);
+		expect(store.isFmp4Enabled).toBe(false);
 		expect(store.isExperimentalDownloadsEnabled).toBe(true);
 
 		store.reset();
@@ -114,7 +114,7 @@ describe('SettingStore', () => {
 		expect(store.isSystemThemeEnabled).toBe(false);
 		expect(store.theme).toBe(Themes.dark);
 		expect(store.isNativeVideoPlayerEnabled).toBe(false);
-		expect(store.isFmp4Enabled).toBe(false);
+		expect(store.isFmp4Enabled).toBe(true);
 		expect(store.isExperimentalDownloadsEnabled).toBe(false);
 	});
 });


### PR DESCRIPTION
We started using fMP4 by default so might as well do the same for the native player 🤷‍♂️ 