### PR TITLE
Patch metro config to fix invalid native module urls

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -9,4 +9,13 @@ const defaultConfig = getDefaultConfig(__dirname);
 
 defaultConfig.resolver.assetExts.push('staticjs');
 
+defaultConfig.server.rewriteRequestUrl = (url) => {
+	if (!url.endsWith('.bundle')) {
+		return url;
+	}
+	// https://github.com/facebook/react-native/issues/36794
+	// JavaScriptCore strips query strings, so try to re-add them with a best guess.
+	return url + '?platform=ios&dev=true&minify=false&modulesOnly=false&runModule=true';
+};
+
 module.exports = defaultConfig;


### PR DESCRIPTION
Fixes a build warning in metro due to trying to bundle native modules with invalid urls

Refs: https://stackoverflow.com/a/77353772