### PR TITLE
Fix white screen when the content process terminates

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -204,6 +204,11 @@ const HomeScreen = observer(() => {
 						onLoadEnd={() => {
 							setIsLoading(false);
 						}}
+						// Reload the webview if the process terminated in the background
+						// refs: https://github.com/react-native-webview/react-native-webview/blob/1d8205af06dbb0bad0d8f208bb2a37ce5f732fd3/docs/Reference.md#oncontentprocessdidterminate
+						onContentProcessDidTerminate={() => {
+							webview.current?.reload();
+						}}
 					/>
 					<AudioPlayer/>
 					<VideoPlayer/>

--- a/screens/__tests__/__snapshots__/HomeScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/HomeScreen.test.js.snap
@@ -138,6 +138,7 @@ exports[`HomeScreen should render correctly 1`] = `
         },
       ]
     }
+    onContentProcessDidTerminate={[Function]}
     onError={[Function]}
     onHttpError={[Function]}
     onLoadEnd={[Function]}


### PR DESCRIPTION
Forces the webview to reload when the content process terminates.

This fix comes directly from the react native webview readme: https://github.com/react-native-webview/react-native-webview/blob/1d8205af06dbb0bad0d8f208bb2a37ce5f732fd3/docs/Reference.md#oncontentprocessdidterminate

Fixes #396 