### PR TITLE
Add audio channels to profile builder options

### DIFF
--- a/assets/js/NativeShell.staticjs
+++ b/assets/js/NativeShell.staticjs
@@ -69,6 +69,7 @@ window.NativeShell = {
 
 		getDeviceProfile: function(profileBuilder) {
 			const profile = profileBuilder({
+				audioChannels: 6,
 				enableMkvProgressive: false,
 				disableHlsVideoAudioCodecs: [ 'opus' ]
 			});


### PR DESCRIPTION
Adds the supported audio channels to the profile builder options in the native shell since it doesn't seem to be detected properly in the webview.

Fixes #413 