### PR TITLE
Add user device name entitlement

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,6 +30,9 @@
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",
+      "entitlements": [
+        "com.apple.developer.device-information.user-assigned-device-name"
+      ],
       "infoPlist": {
         "NSCameraUsageDescription": "Allow $(PRODUCT_NAME) to access your camera.",
         "UIBackgroundModes": [

--- a/ios/Jellyfin/Jellyfin.entitlements
+++ b/ios/Jellyfin/Jellyfin.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>0</key>
+    <string>com.apple.developer.device-information.user-assigned-device-name</string>
     <key>aps-environment</key>
     <string>development</string>
   </dict>


### PR DESCRIPTION
Adds the user device name entitlement so we can access the actual device name instead of the generic name (i.e. "iPhone").

Note: we will need to follow the process described [here](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.developer.device-information.user-assigned-device-name#Discussion) to request this entitlement.

Fixes #590 