### PR TITLE
Update licenser plugin setttings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
     "files.associations": {
         "*.staticjs": "javascript"
     },
-    "licenser.customHeader": "This Source Code Form is subject to the terms of the Mozilla Public\nLicense, v. 2.0. If a copy of the MPL was not distributed with this\nfile, You can obtain one at http://mozilla.org/MPL/2.0/.",
-    "licenser.license": "Custom",
+    "licenser.author": "Jellyfin Contributors",
+    "licenser.license": "MPLv2",
     "licenser.useSingleLineStyle": false,
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": "explicit"


### PR DESCRIPTION
Updates the licenser VS Code plugin settings so that the copyright is included in the header with "Jellyfin Contributors" as the author.

```javascript
/**
 * Copyright (c) 2025 Jellyfin Contributors
 *
 * This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
```