### PR TITLE
Hide home screen indicator when fullscreen active

### DIFF
--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -1,10 +1,12 @@
 /**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import { getFocusedRouteNameFromRoute } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as SplashScreen from 'expo-splash-screen';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -16,7 +18,7 @@ import AddServerScreen from '../screens/AddServerScreen';
 
 import TabNavigator from './TabNavigator';
 
-const AppStack = createStackNavigator();
+const AppStack = createNativeStackNavigator();
 
 const AppNavigator = observer(() => {
 	const { rootStore } = useStores();
@@ -29,7 +31,7 @@ const AppNavigator = observer(() => {
 		<AppStack.Navigator
 			initialRouteName={(rootStore.serverStore.servers?.length > 0) ? Screens.MainScreen : Screens.AddServerScreen}
 			screenOptions={{
-				headerMode: 'screen',
+				autoHideHomeIndicator: rootStore.isFullscreen,
 				headerShown: false
 			}}
 		>
@@ -43,10 +45,9 @@ const AppNavigator = observer(() => {
 						// If state doesn't exist, we need to default to `screen` param if available, or the initial screen
 						// In our case, it's "Main" as that's the first screen inside the navigator
 						route.params?.screen || Screens.MainScreen;
-					return ({
-						headerShown: false,
+					return {
 						title: t(`headings.${routeName.toLowerCase()}`)
-					});
+					};
 				}}
 			/>
 			<AppStack.Screen

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,7 +1,9 @@
 /**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { observer } from 'mobx-react-lite';
@@ -124,10 +126,6 @@ const HomeScreen = observer(() => {
 	const safeAreaEdges = [ 'right', 'left' ];
 	if (Platform.OS !== 'ios' || rootStore.isFullscreen) {
 		safeAreaEdges.push('top');
-	}
-	// Bottom spacer is handled by tab bar except in fullscreen
-	if (rootStore.isFullscreen) {
-		safeAreaEdges.push('bottom');
 	}
 	// Hide webview until loaded
 	const webviewStyle = (isLoading || httpErrorStatus) ? StyleSheet.compose(styles.container, styles.loading) : styles.container;


### PR DESCRIPTION
Changes the app navigator to use a native stack so we can request that the home indicator be hidden when a fullscreen view is active.

Fixes #188 