### PR TITLE
Add patch for boost download url

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -34,7 +34,9 @@ jobs:
           cache: npm
 
       - name: Install Node.js dependencies
-        run: npm ci --no-audit
+        run: |
+          npm ci --no-audit
+          git apply patches/boost1760.patch
 
       - name: Install Pods
         run: |

--- a/patches/boost1760.patch
+++ b/patches/boost1760.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native/third-party-podspecs/boost.podspec b/node_modules/react-native/third-party-podspecs/boost.podspec
+index 3950fce..3ae78ba 100644
+--- a/node_modules/react-native/third-party-podspecs/boost.podspec
++++ b/node_modules/react-native/third-party-podspecs/boost.podspec
+@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
+   spec.homepage = 'http://www.boost.org'
+   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+   spec.authors = 'Rene Rivera'
+-  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
++  spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',
+                   :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
+ 
+   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
* Adds a patch to point the boost download url to their archives. It seems their JFrog artifactory subscription might have lapsed (again).

Related:
* https://github.com/facebook/react-native/issues/42180
* https://github.com/boostorg/boost/issues/996