### PR TITLE
Bump versions for initial 1.7.0 build

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "platforms": [
       "ios"
     ],
-    "version": "1.6.1",
+    "version": "1.7.0",
     "orientation": "default",
     "primaryColor": "#00a4dc",
     "backgroundColor": "#101010",
@@ -26,7 +26,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "1.6.1.0",
+      "buildNumber": "1.7.0.0",
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.6.1</string>
+    <string>1.7.0</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -30,7 +30,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.6.1.0</string>
+    <string>1.7.0.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-expo",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-expo",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",


### PR DESCRIPTION
Bumps versions for an initial 1.7.0 build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated app version to 1.7.0 across all relevant configuration files.
  - Updated iOS build number to 1.7.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->