### PR TITLE
Add messaging on empty downloads screen

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -74,6 +74,11 @@
     "help": "Getting Help"
   },
   "alerts": {
+    "deleteDownloads": {
+        "title": "Delete Downloads",
+        "description": "These items will be permanently deleted from this device.",
+        "confirm": "Delete {{downloadCount}} Downloads"
+    },
     "deleteServer": {
       "title": "Delete Server",
       "description": "Are you sure you want to delete the server {{serverName}}?",

--- a/langs/en.json
+++ b/langs/en.json
@@ -26,6 +26,12 @@
       "noConnection": "Could not connect to server"
     }
   },
+  "downloads": {
+    "noDownloads": {
+        "heading": "No downloads",
+        "description": "Content you download will appear here."
+    }
+  },
   "home": {
     "errors": {
         "502": {

--- a/screens/DownloadScreen.js
+++ b/screens/DownloadScreen.js
@@ -13,6 +13,7 @@ import { Button, ThemeContext } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import DownloadListItem from '../components/DownloadListItem';
+import ErrorView from '../components/ErrorView';
 import MediaTypes from '../constants/MediaTypes';
 import { useStores } from '../hooks/useStores';
 
@@ -117,35 +118,46 @@ const DownloadScreen = () => {
 			}}
 			edges={[ 'right', 'left' ]}
 		>
-			<FlatList
-				data={Array.from(downloadStore.downloads.values())}
-				extraData={downloadStore.downloads}
-				renderItem={({ item, index }) => (
-					<DownloadListItem
-						item={item}
-						index={index}
-						isEditMode={isEditMode}
-						isSelected={selectedItems.includes(item)}
-						onSelect={() => {
-							if (selectedItems.includes(item)) {
-								setSelectedItems(selectedItems.filter(selected => selected !== item));
-							} else {
-								setSelectedItems([ ...selectedItems, item ]);
-							}
-						}}
-						onPlay={async () => {
-							item.isNew = false;
-							mediaStore.set({
-								isLocalFile: true,
-								type: MediaTypes.Video,
-								uri: item.uri
-							});
-						}}
-					/>
-				)}
-				keyExtractor={(item, index) => `download-${index}-${item.key}`}
-				contentContainerStyle={styles.listContainer}
-			/>
+			{downloadStore.downloads.size > 0 ? (
+				<FlatList
+					data={Array.from(downloadStore.downloads.values())}
+					extraData={downloadStore.downloads}
+					renderItem={({ item, index }) => (
+						<DownloadListItem
+							item={item}
+							index={index}
+							isEditMode={isEditMode}
+							isSelected={selectedItems.includes(item)}
+							onSelect={() => {
+								if (selectedItems.includes(item)) {
+									setSelectedItems(selectedItems.filter(selected => selected !== item));
+								} else {
+									setSelectedItems([ ...selectedItems, item ]);
+								}
+							}}
+							onPlay={async () => {
+								item.isNew = false;
+								mediaStore.set({
+									isLocalFile: true,
+									type: MediaTypes.Video,
+									uri: item.uri
+								});
+							}}
+						/>
+					)}
+					keyExtractor={(item, index) => `download-${index}-${item.key}`}
+					contentContainerStyle={styles.listContainer}
+				/>
+			) : (
+				<ErrorView
+					icon={{
+						name: 'download-circle-outline',
+						type: 'material-community'
+					}}
+					heading={t('downloads.noDownloads.heading')}
+					message={t('downloads.noDownloads.description')}
+				/>
+			)}
 		</SafeAreaView>
 	);
 };

--- a/screens/DownloadScreen.js
+++ b/screens/DownloadScreen.js
@@ -43,15 +43,15 @@ const DownloadScreen = () => {
 
 		function onDeleteItems(downloads) {
 			Alert.alert(
-				'Delete Downloads',
-				'These items will be permanently deleted from this device.',
+				t('alerts.deleteDownloads.title'),
+				t('alerts.deleteDownloads.description'),
 				[
 					{
 						text: t('common.cancel'),
 						onPress: exitEditMode
 					},
 					{
-						text: `Delete ${downloads.length} Downloads`,
+						text: t('alerts.deleteDownloads.confirm', { downloadCount: downloads.length }),
 						onPress: async () => {
 							await Promise.all(downloads.map(deleteItem));
 							exitEditMode();


### PR DESCRIPTION
* Adds delete download copy to translations
* Adds messaging on empty downloads screen

![Simulator Screenshot - iPhone 14 Plus - 2025-05-25 at 01 07 44](https://github.com/user-attachments/assets/5fcaa3cf-36fb-407e-ba30-dc65c6b64611)

Part of #372 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a user-friendly message and icon when there are no downloads available.
- **Enhancements**
  - Improved download deletion alerts with localized text and dynamic download count.
  - All alert dialogs and messages related to downloads now support internationalization for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->