### PR TITLE
Replace codecov test coverage reporting with sonarcloud

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -68,7 +68,19 @@ jobs:
         run: npm ci --no-audit
 
       - name: Run jest
-        run: npx jest
+        run: npx jest --coverage
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+      - name: SonarCloud scan
+        if: ${{ github.repository == 'jellyfin/jellyfin-expo' }}
+        uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838 # v3.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.pullrequest.provider=github
+            -Dsonar.pullrequest.github.repository=${{ github.repository }}
+            -Dsonar.pullrequest.github.token.secured=${{ secrets.GITHUB_TOKEN }}
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 <a href="https://translate.jellyfin.org/projects/jellyfin/jellyfin-expo/?utm_source=widget">
 <img alt="Translation Status" src="https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-expo/svg-badge.svg"/>
 </a>
-<a href="https://codecov.io/gh/jellyfin/jellyfin-expo">
-<img alt="Codecov" src="https://img.shields.io/codecov/c/github/jellyfin/jellyfin-expo?token=Wk8RS9tDnb">
+<a href="https://sonarcloud.io/component_measures?metric=coverage&id=jellyfin_jellyfin-expo">
+<img alt="Sonar Coverage" src="https://img.shields.io/sonar/coverage/jellyfin_jellyfin-expo/master?server=https%3A%2F%2Fsonarcloud.io">
 </a>
 <br/>
 <a href="https://opencollective.com/jellyfin"><img alt="Donate" src="https://img.shields.io/opencollective/all/jellyfin.svg?label=backers"/></a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        threshold: 2.5%
-        if_not_found: success # no commit found? still set a success
-    patch: off

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=jellyfin_jellyfin-expo
 sonar.organization=jellyfin
 
 # Paths for sources
-sonar.exclusions = \.*,fastlane,ios,langs,patches,**/__tests__/**/*,**/__mocks__/**/*
+sonar.exclusions = **/.*,fastlane/**,ios/**,langs/**,patches/**,**/__tests__/**,**/__mocks__/**
 
 # Paths for tests
 sonar.test.inclusions = **/__tests__/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.projectKey=jellyfin_jellyfin-expo
+sonar.organization=jellyfin
+
+# Paths for sources
+sonar.exclusions = \.*,fastlane,ios,langs,patches,**/__tests__/**/*,**/__mocks__/**/*
+
+# Paths for tests
+sonar.test.inclusions = **/__tests__/**/*
+
+# Coverage report paths
+sonar.javascript.lcov.reportPaths = coverage/lcov.info


### PR DESCRIPTION
Replaces our usage of codecov for test coverage reporting with sonarcloud to reduce noise on PRs and redundant tooling

Fixes #635 