### PR TITLE
Update xcode version to 16.2 for AppStore requirements

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,7 +30,7 @@ platform :ios do
       ]
     )
 
-    xcodes(version: "15.4")
+    xcodes(version: "16.2")
 
     app_store_connect_api_key(
       is_key_content_base64: true,


### PR DESCRIPTION
* Updates xcode version to 16.2 for AppStore requirements

Related CI failure: https://github.com/jellyfin/jellyfin-expo/actions/runs/15357218085/job/43218644194