### PR TITLE
Add release link to AppInfoFooter

### DIFF
--- a/components/AppInfoFooter.js
+++ b/components/AppInfoFooter.js
@@ -14,6 +14,12 @@ import { Text, ThemeContext } from 'react-native-elements';
 
 import Screens from '../constants/Screens';
 import { getAppName } from '../utils/Device';
+import { openBrowser } from '../utils/WebBrowser';
+
+// NOTE: eslint randomly started blowing up with this inline in the JSX
+const getDisplayVersion = (appVersion, buildVersion) => `${appVersion} (${buildVersion})`;
+
+const getReleaseUrl = version => encodeURI(`https://github.com/jellyfin/jellyfin-ios/releases/v${version}`);
 
 const AppInfoFooter = () => {
 	const navigation = useNavigation();
@@ -29,14 +35,16 @@ const AppInfoFooter = () => {
 			<Text
 				testID='app-name'
 				style={textStyle}
-				onLongPress={() => {
-					navigation.navigate(Screens.DevSettingsScreen);
-				}}
 			>
 				{getAppName()}
 			</Text>
-			<Text testID='app-version' style={textStyle}>
-				{`${nativeApplicationVersion} (${nativeBuildVersion})`}
+			<Text
+				testID='app-version'
+				style={textStyle}
+				onPress={() => openBrowser(getReleaseUrl(nativeBuildVersion))}
+				onLongPress={() => navigation.navigate(Screens.DevSettingsScreen)}
+			>
+				{getDisplayVersion(nativeApplicationVersion, nativeBuildVersion)}
 			</Text>
 		</View>
 	);

--- a/components/__tests__/AppInfoFooter.test.js
+++ b/components/__tests__/AppInfoFooter.test.js
@@ -14,10 +14,12 @@ import React from 'react';
 
 import '../../i18n';
 import Screens from '../../constants/Screens';
+import { openBrowser } from '../../utils/WebBrowser';
 import AppInfoFooter from '../AppInfoFooter';
 
 jest.mock('expo-application');
 jest.mock('expo-device');
+jest.mock('../../utils/WebBrowser');
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => {
@@ -42,10 +44,13 @@ describe('AppInfoFooter', () => {
 			</NavigationContainer>
 		);
 
-		const appName = getByTestId('app-name');
-		expect(appName).toHaveTextContent('Jellyfin (Test OS)');
-		fireEvent(appName, 'onLongPress');
+		expect(getByTestId('app-name')).toHaveTextContent('Jellyfin (Test OS)');
+
+		const appVersion = getByTestId('app-version');
+		expect(appVersion).toHaveTextContent('1.0.0 (1.0.0.0)');
+		fireEvent.press(appVersion);
+		expect(openBrowser).toHaveBeenCalledWith('https://github.com/jellyfin/jellyfin-ios/releases/v1.0.0.0');
+		fireEvent(appVersion, 'onLongPress');
 		expect(mockNavigate).toHaveBeenCalledWith(Screens.DevSettingsScreen);
-		expect(getByTestId('app-version')).toHaveTextContent('1.0.0 (1.0.0.0)');
 	});
 });

--- a/screens/__tests__/__snapshots__/SettingsScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/SettingsScreen.test.js.snap
@@ -697,7 +697,6 @@ exports[`SettingsScreen should render correctly 1`] = `
           }
         >
           <Text
-            onLongPress={[Function]}
             style={
               Object {
                 "color": "#43484d",
@@ -709,6 +708,8 @@ exports[`SettingsScreen should render correctly 1`] = `
             Jellyfin (mock)
           </Text>
           <Text
+            onLongPress={[Function]}
+            onPress={[Function]}
             style={
               Object {
                 "color": "#43484d",


### PR DESCRIPTION
Adds a link to the release notes by pressing the version in the app info footer on the settings screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tapping the app version in the App Info footer opens the corresponding GitHub release page in your browser.

* **Improvements**
  * Long-pressing the app version opens Developer Settings.
  * App version text now uses theme-aware styling and a helper for consistent "appVersion (buildVersion)" display (no visible change).

* **Tests**
  * Added tests with a browser-open mock to validate tap and long-press behaviors and displayed version text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->