### PR TITLE
Bump build version to 1.7.0.4

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "1.7.0.3",
+      "buildNumber": "1.7.0.4",
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -30,7 +30,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.7.0.3</string>
+    <string>1.7.0.4</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Bump the build version for a new TestFlight release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented iOS build number from 1.7.0.3 to 1.7.0.4 for the next release build.
  * Synchronized version metadata across configuration and iOS bundle settings for consistency.
  * No functional or UI changes; this affects only build/version identifiers shown in system settings and distribution channels (e.g., TestFlight/App Store) to support proper update delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->