### PR TITLE
Convert DownloadScreen and dependencies to typescript

### DIFF
--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -1,17 +1,35 @@
 /**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import PropTypes from 'prop-types';
-import React from 'react';
+import React, { FC } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { Button, ListItem } from 'react-native-elements';
 
+import type DownloadModel from '../models/DownloadModel';
 import { getIconName } from '../utils/Icons';
 
-const DownloadListItem = ({ item, index, onSelect, onPlay, isEditMode = false, isSelected = false }) => (
+interface DownloadListItemProps {
+	item: DownloadModel;
+	index: number;
+	onSelect: (item: DownloadModel) => void;
+	onPlay: (item: DownloadModel) => void;
+	isEditMode?: boolean;
+	isSelected?: boolean;
+}
+
+const DownloadListItem: FC<DownloadListItemProps> = ({
+	item,
+	index,
+	onSelect,
+	onPlay,
+	isEditMode = false,
+	isSelected = false
+}) => (
 	<ListItem
 		topDivider={index === 0}
 		bottomDivider
@@ -47,13 +65,6 @@ const DownloadListItem = ({ item, index, onSelect, onPlay, isEditMode = false, i
 	</ListItem>
 );
 
-DownloadListItem.propTypes = {
-	item: PropTypes.object.isRequired,
-	index: PropTypes.number.isRequired,
-	onSelect: PropTypes.func.isRequired,
-	onPlay: PropTypes.func.isRequired,
-	isEditMode: PropTypes.bool,
-	isSelected: PropTypes.bool
-};
+DownloadListItem.displayName = 'DownloadListItem';
 
 export default DownloadListItem;

--- a/components/ErrorView.tsx
+++ b/components/ErrorView.tsx
@@ -1,17 +1,34 @@
 /**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
+
+import React, { type FC, useContext } from 'react';
 import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Button, Icon, Text, ThemeContext } from 'react-native-elements';
 
 import { isCompact } from '../utils/Device';
 import { getIconName } from '../utils/Icons';
 
-const ErrorView = ({
+interface IconProps {
+	name: string;
+	type?: string;
+}
+
+interface ErrorViewProps {
+	icon?: IconProps;
+	heading: string;
+	message: string;
+	details?: string[];
+	buttonIcon?: IconProps;
+	buttonTitle?: string;
+	onPress?: () => void;
+}
+
+const ErrorView: FC<ErrorViewProps> = ({
 	icon = { name: getIconName('alert'), type: 'ionicon' },
 	heading,
 	message,
@@ -27,7 +44,7 @@ const ErrorView = ({
 	return (
 		<View style={{
 			...styles.container,
-			backgroundColor: theme.colors.background
+			backgroundColor: theme.colors?.background
 		}}>
 			<View style={styles.body}>
 				<Icon
@@ -74,25 +91,9 @@ const ErrorView = ({
 	);
 };
 
-ErrorView.propTypes = {
-	icon: PropTypes.shape({
-		name: PropTypes.string,
-		type: PropTypes.string
-	}),
-	heading: PropTypes.string.isRequired,
-	message: PropTypes.string.isRequired,
-	details: PropTypes.arrayOf(PropTypes.string),
-	buttonIcon: PropTypes.shape({
-		name: PropTypes.string,
-		type: PropTypes.string
-	}),
-	buttonTitle: PropTypes.string,
-	onPress: PropTypes.func
-};
-
 const styles = StyleSheet.create({
 	container: {
-		...StyleSheet.absoluteFill,
+		...StyleSheet.absoluteFillObject,
 		flex: 1,
 		paddingHorizontal: 15
 	},
@@ -114,5 +115,7 @@ const styles = StyleSheet.create({
 		fontSize: 15
 	}
 });
+
+ErrorView.displayName = 'ErrorView';
 
 export default ErrorView;

--- a/constants/MediaTypes.js
+++ b/constants/MediaTypes.js
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
+/** @deprecated Use the `MediaType` enum from the SDK. */
 export default {
 	Audio: 'Audio',
 	Video: 'Video',

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -1,9 +1,12 @@
 /**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import * as FileSystem from 'expo-file-system';
 import React, { useCallback, useContext, useState } from 'react';
@@ -14,9 +17,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import DownloadListItem from '../components/DownloadListItem';
 import ErrorView from '../components/ErrorView';
-import MediaTypes from '../constants/MediaTypes';
 import { Screens } from '../constants/Screens';
 import { useStores } from '../hooks/useStores';
+import type DownloadModel from '../models/DownloadModel';
 
 const DownloadScreen = () => {
 	const navigation = useNavigation();
@@ -24,7 +27,7 @@ const DownloadScreen = () => {
 	const { t } = useTranslation();
 	const { theme } = useContext(ThemeContext);
 	const [ isEditMode, setIsEditMode ] = useState(false);
-	const [ selectedItems, setSelectedItems ] = useState([]);
+	const [ selectedItems, setSelectedItems ] = useState<DownloadModel[]>([]);
 
 	function exitEditMode() {
 		setIsEditMode(false);
@@ -32,7 +35,7 @@ const DownloadScreen = () => {
 	}
 
 	React.useLayoutEffect(() => {
-		async function deleteItem(download) {
+		async function deleteItem(download: DownloadModel) {
 			// TODO: Add user messaging on errors
 			try {
 				await FileSystem.deleteAsync(download.localPath);
@@ -43,7 +46,7 @@ const DownloadScreen = () => {
 			}
 		}
 
-		function onDeleteItems(downloads) {
+		function onDeleteItems(downloads: DownloadModel[]) {
 			Alert.alert(
 				t('alerts.deleteDownloads.title'),
 				t('alerts.deleteDownloads.description'),
@@ -119,7 +122,7 @@ const DownloadScreen = () => {
 		<SafeAreaView
 			style={{
 				...styles.container,
-				backgroundColor: theme.colors.background
+				backgroundColor: theme.colors?.background
 			}}
 			edges={[ 'right', 'left' ]}
 		>
@@ -144,7 +147,7 @@ const DownloadScreen = () => {
 								item.isNew = false;
 								mediaStore.set({
 									isLocalFile: true,
-									type: MediaTypes.Video,
+									type: MediaType.Video,
 									uri: item.uri
 								});
 							}}

--- a/stores/MediaStore.ts
+++ b/stores/MediaStore.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { create } from 'zustand';
 
 import { ticksToMs } from '../utils/Time';
@@ -14,7 +15,7 @@ import { logger } from './middleware/logger';
 
 type State = {
 	/** The media type being played */
-	type: string | null,
+	type: MediaType | null,
 
 	/** URI of the current media file */
 	uri: string | null,

--- a/stores/__tests__/MediaStore.test.js
+++ b/stores/__tests__/MediaStore.test.js
@@ -1,16 +1,18 @@
 /**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
  * @jest-environment jsdom
  * @jest-environment-options {"url": "https://jestjs.io/"}
  */
-import { renderHook } from '@testing-library/react';
 
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
+import { renderHook } from '@testing-library/react';
 import { act } from '@testing-library/react-native';
 
-import MediaTypes from '../../constants/MediaTypes';
 import { useMediaStore } from '../MediaStore';
 
 describe('MediaStore', () => {
@@ -38,7 +40,7 @@ describe('MediaStore', () => {
 
 		act(() => {
 			store.result.current.set({
-				type: MediaTypes.Video,
+				type: MediaType.Video,
 				uri: 'https://foobar',
 				isFinished: true,
 				isLocalFile: true,
@@ -50,7 +52,7 @@ describe('MediaStore', () => {
 			});
 		});
 
-		expect(store.result.current.type).toBe(MediaTypes.Video);
+		expect(store.result.current.type).toBe(MediaType.Video);
 		expect(store.result.current.uri).toBe('https://foobar');
 		expect(store.result.current.backdropUri).toBe('https://foobar');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Migrated components to TypeScript typings and adopted the SDK MediaType enum for consistent media handling; improved type-safety for downloads and media store.
- Style
  - Improved theming/background handling in views; no visual changes expected.
- Tests
  - Updated tests to use the new MediaType enum.
- Chores
  - Updated license headers and marked legacy media constant as deprecated.

No user-facing features added; stability and consistency improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->