### PR TITLE
Update app name formatting for api and display

### DIFF
--- a/components/AppInfoFooter.tsx
+++ b/components/AppInfoFooter.tsx
@@ -13,7 +13,7 @@ import { StyleSheet, View } from 'react-native';
 import { Text, ThemeContext } from 'react-native-elements';
 
 import { Screens } from '../constants/Screens';
-import { getAppName } from '../utils/Device';
+import { getAppDisplayName } from '../utils/Device';
 import { openBrowser } from '../utils/WebBrowser';
 
 // NOTE: eslint randomly started blowing up with this inline in the JSX
@@ -36,7 +36,7 @@ const AppInfoFooter = () => {
 				testID='app-name'
 				style={textStyle}
 			>
-				{getAppName()}
+				{getAppDisplayName()}
 			</Text>
 			<Text
 				testID='app-version'

--- a/components/__tests__/AppInfoFooter.test.js
+++ b/components/__tests__/AppInfoFooter.test.js
@@ -44,7 +44,7 @@ describe('AppInfoFooter', () => {
 			</NavigationContainer>
 		);
 
-		expect(getByTestId('app-name')).toHaveTextContent('Jellyfin (Test OS)');
+		expect(getByTestId('app-name')).toHaveTextContent('Jellyfin for Test OS');
 
 		const appVersion = getByTestId('app-version');
 		expect(appVersion).toHaveTextContent('1.0.0 (1.0.0.0)');

--- a/components/__tests__/NativeShellWebView.test.js
+++ b/components/__tests__/NativeShellWebView.test.js
@@ -29,7 +29,7 @@ useStores.mockImplementation(() => ({
 ));
 
 jest.mock('../../utils/Device');
-getAppName.mockImplementation(() => 'Jellyfin (iOS)');
+getAppName.mockReturnValue('Jellyfin iOS');
 getDeviceProfile.mockImplementation(() => ({}));
 getSafeDeviceName.mockImplementation(() => 'Test Device');
 

--- a/components/__tests__/__snapshots__/NativeShellWebView.test.js.snap
+++ b/components/__tests__/__snapshots__/NativeShellWebView.test.js.snap
@@ -43,7 +43,7 @@ exports[`NativeShellWebView should render correctly 1`] = `
         decelerationRate={0.998}
         injectedJavaScriptBeforeContentLoaded="
 window.ExpoAppInfo = {
-	appName: 'Jellyfin (iOS)',
+	appName: 'Jellyfin iOS',
 	appVersion: 'mock',
 	deviceId: 'undefined',
 	deviceName: 'Test Device'

--- a/screens/__tests__/__snapshots__/SettingsScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/SettingsScreen.test.js.snap
@@ -705,7 +705,7 @@ exports[`SettingsScreen should render correctly 1`] = `
             }
             testID="app-name"
           >
-            Jellyfin (mock)
+            Jellyfin for mock
           </Text>
           <Text
             onLongPress={[Function]}

--- a/utils/Device.ts
+++ b/utils/Device.ts
@@ -17,8 +17,14 @@ import iOS10Profile from './profiles/ios-10';
 import iOS12Profile from './profiles/ios-12';
 import iOSFmp4Profile from './profiles/ios-fmp4';
 
+/** Gets the app name used for API requests. */
 export function getAppName() {
-	return `Jellyfin (${Device.osName})`;
+	return `Jellyfin ${Device.osName}`;
+}
+
+/** Gets the app name used for display within the app. */
+export function getAppDisplayName() {
+	return `Jellyfin for ${Device.osName}`;
 }
 
 export function getSafeDeviceName() {

--- a/utils/__tests__/Device.test.js
+++ b/utils/__tests__/Device.test.js
@@ -7,7 +7,7 @@ import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
 
-import { getAppName, getDeviceProfile, getSafeDeviceName, isCompact, isSystemThemeSupported } from '../Device';
+import { getAppName, getAppDisplayName, getDeviceProfile, getSafeDeviceName, isCompact, isSystemThemeSupported } from '../Device';
 import iOSProfile from '../profiles/ios';
 import iOS10Profile from '../profiles/ios-10';
 import iOS12Profile from '../profiles/ios-12';
@@ -22,7 +22,13 @@ describe('Device', () => {
 
 	describe('getAppName()', () => {
 		it('should return the app name including the os name', () => {
-			expect(getAppName()).toBe('Jellyfin (mock)');
+			expect(getAppName()).toBe('Jellyfin mock');
+		});
+	});
+
+	describe('getAppDisplayName()', () => {
+		it('should return the app display name including the os name', () => {
+			expect(getAppDisplayName()).toBe('Jellyfin for mock');
 		});
 	});
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - App footer now displays the app name as “Jellyfin for <OS>” for clearer branding.

- Style
  - Refined app-name wording by removing parentheses and using a more natural phrase.

- Tests
  - Updated test expectations and mocks to match the new display format; added coverage for the display-name output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->