### PR TITLE
Add menu to download list item

### DIFF
--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -6,18 +6,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import React, { FC } from 'react';
+import { MenuView } from '@react-native-menu/menu';
+import React, { type FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ActivityIndicator } from 'react-native';
 import { Button, ListItem } from 'react-native-elements';
 
 import type DownloadModel from '../models/DownloadModel';
-import { getIconName } from '../utils/Icons';
 
 interface DownloadListItemProps {
 	item: DownloadModel;
 	index: number;
-	onSelect: (item: DownloadModel) => void;
-	onPlay: (item: DownloadModel) => void;
+	onSelect: () => void;
+	onPlay: () => void;
+	onDelete: () => void;
 	isEditMode?: boolean;
 	isSelected?: boolean;
 }
@@ -27,43 +29,82 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	index,
 	onSelect,
 	onPlay,
+	onDelete,
 	isEditMode = false,
 	isSelected = false
-}) => (
-	<ListItem
-		topDivider={index === 0}
-		bottomDivider
-	>
-		{isEditMode &&
+}) => {
+	const { t } = useTranslation();
+
+	return (
+		<ListItem
+			testID='list-item'
+			topDivider={index === 0}
+			bottomDivider
+			onPress={() => {
+				if (isEditMode) onSelect();
+				else onPlay();
+			}}
+		>
+			{isEditMode &&
 			<ListItem.CheckBox
 				testID='select-checkbox'
-				onPress={() => onSelect(item)}
+				onPress={onSelect}
 				checked={isSelected}
 			/>
-		}
-		<ListItem.Content>
-			<ListItem.Title testID='title'>
-				{item.title}
-			</ListItem.Title>
-			<ListItem.Subtitle testID='subtitle'>
-				{item.localFilename}
-			</ListItem.Subtitle>
-		</ListItem.Content>
-		{item.isComplete ?
-			<Button
-				testID='play-button'
-				type='clear'
-				icon={{
-					name: getIconName('play'),
-					type: 'ionicon'
-				}}
-				disabled={isEditMode}
-				onPress={() => onPlay(item)}
-			/> :
-			<ActivityIndicator testID='loading-indicator' />
-		}
-	</ListItem>
-);
+			}
+			<ListItem.Content>
+				<ListItem.Title testID='title'>
+					{item.title}
+				</ListItem.Title>
+				<ListItem.Subtitle testID='subtitle'>
+					{item.localFilename}
+				</ListItem.Subtitle>
+			</ListItem.Content>
+			{item.isComplete ? (
+				<MenuView
+					testID='menu-view'
+					actions={[
+						{
+							id: 'play_in_app',
+							title: t('common.play'),
+							image: 'play'
+						},
+						{
+							id: 'delete',
+							title: t('common.delete'),
+							attributes: {
+								destructive: true
+							},
+							image: 'trash'
+						}
+					]}
+					onPressAction={({ nativeEvent }) => {
+						switch (nativeEvent.event) {
+							case 'play_in_app':
+								return onPlay();
+							case 'delete':
+								return onDelete();
+						}
+					}}
+					shouldOpenOnLongPress={false}
+					themeVariant='dark'
+				>
+					<Button
+						testID='menu-button'
+						type='clear'
+						icon={{
+							name: 'ellipsis-horizontal',
+							type: 'ionicon'
+						}}
+						disabled={isEditMode}
+					/>
+				</MenuView>
+			) :
+				<ActivityIndicator testID='loading-indicator' />
+			}
+		</ListItem>
+	);
+};
 
 DownloadListItem.displayName = 'DownloadListItem';
 

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -50,13 +50,22 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 				testID='select-checkbox'
 				onPress={onSelect}
 				checked={isSelected}
+				accessibilityRole='checkbox'
 			/>
 			}
 			<ListItem.Content>
-				<ListItem.Title testID='title'>
+				<ListItem.Title
+					testID='title'
+					numberOfLines={1}
+					ellipsizeMode='tail'
+				>
 					{item.title}
 				</ListItem.Title>
-				<ListItem.Subtitle testID='subtitle'>
+				<ListItem.Subtitle
+					testID='subtitle'
+					numberOfLines={1}
+					ellipsizeMode='tail'
+				>
 					{item.localFilename}
 				</ListItem.Subtitle>
 			</ListItem.Content>

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -24,6 +24,11 @@ interface DownloadListItemProps {
 	isSelected?: boolean;
 }
 
+const MenuAction = {
+	Delete: 'delete',
+	PlayInApp: 'play_in_app'
+} as const;
+
 const DownloadListItem: FC<DownloadListItemProps> = ({
 	item,
 	index,
@@ -37,12 +42,12 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 
 	const menuActions = useMemo(() => [
 		{
-			id: 'play_in_app',
+			id: MenuAction.PlayInApp,
 			title: t('common.play'),
 			image: 'play'
 		},
 		{
-			id: 'delete',
+			id: MenuAction.Delete,
 			title: t('common.delete'),
 			attributes: {
 				destructive: true
@@ -53,10 +58,12 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 
 	const onMenuPress = useCallback(({ nativeEvent }: NativeActionEvent) => {
 		switch (nativeEvent.event) {
-			case 'play_in_app':
+			case MenuAction.PlayInApp:
 				return onPlay();
-			case 'delete':
+			case MenuAction.Delete:
 				return onDelete();
+			default:
+				console.warn('[DownloadListItem.onMenuPress] unhandled menu press action', nativeEvent.event);
 		}
 	}, [ onDelete, onPlay ]);
 

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -6,8 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { MenuView } from '@react-native-menu/menu';
-import React, { type FC } from 'react';
+import { MenuView, type NativeActionEvent } from '@react-native-menu/menu';
+import React, { useCallback, useMemo, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator } from 'react-native';
 import { Button, ListItem } from 'react-native-elements';
@@ -34,6 +34,31 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	isSelected = false
 }) => {
 	const { t } = useTranslation();
+
+	const menuActions = useMemo(() => [
+		{
+			id: 'play_in_app',
+			title: t('common.play'),
+			image: 'play'
+		},
+		{
+			id: 'delete',
+			title: t('common.delete'),
+			attributes: {
+				destructive: true
+			},
+			image: 'trash'
+		}
+	], [ t ]);
+
+	const onMenuPress = useCallback(({ nativeEvent }: NativeActionEvent) => {
+		switch (nativeEvent.event) {
+			case 'play_in_app':
+				return onPlay();
+			case 'delete':
+				return onDelete();
+		}
+	}, [ onDelete, onPlay ]);
 
 	return (
 		<ListItem
@@ -72,29 +97,8 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			{item.isComplete ? (
 				<MenuView
 					testID='menu-view'
-					actions={[
-						{
-							id: 'play_in_app',
-							title: t('common.play'),
-							image: 'play'
-						},
-						{
-							id: 'delete',
-							title: t('common.delete'),
-							attributes: {
-								destructive: true
-							},
-							image: 'trash'
-						}
-					]}
-					onPressAction={({ nativeEvent }) => {
-						switch (nativeEvent.event) {
-							case 'play_in_app':
-								return onPlay();
-							case 'delete':
-								return onDelete();
-						}
-					}}
+					actions={menuActions}
+					onPressAction={onMenuPress}
 					shouldOpenOnLongPress={false}
 					themeVariant='dark'
 				>

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -10,21 +10,25 @@ import React from 'react';
 import DownloadModel from '../../models/DownloadModel';
 import DownloadListItem from '../DownloadListItem';
 
-const TEST_MODEL = new DownloadModel(
-	'item-id',
-	'server-id',
-	'https://example.com/',
-	'api-key',
-	'title',
-	'file name.mkv',
-	'https://example.com/download'
-);
-
 describe('DownloadListItem', () => {
+	let model;
+
+	beforeEach(() => {
+		model = new DownloadModel(
+			'item-id',
+			'server-id',
+			'https://example.com/',
+			'api-key',
+			'title',
+			'file name.mkv',
+			'https://example.com/download'
+		);
+	});
+
 	it('should render correctly', () => {
 		const { getByTestId, queryByTestId } = render(
 			<DownloadListItem
-				item={TEST_MODEL}
+				item={model}
 				index={0}
 				onSelect={() => { /* no-op */ }}
 				onPlay={() => { /* no-op */ }}
@@ -45,11 +49,11 @@ describe('DownloadListItem', () => {
 		const onPlay = jest.fn();
 		const onDelete = jest.fn();
 
-		TEST_MODEL.isComplete = true;
+		model.isComplete = true;
 
 		const { getByTestId, queryByTestId } = render(
 			<DownloadListItem
-				item={TEST_MODEL}
+				item={model}
 				index={0}
 				onSelect={() => { /* no-op */ }}
 				onPlay={onPlay}
@@ -83,9 +87,11 @@ describe('DownloadListItem', () => {
 	it('should display the select checkbox and handle presses', () => {
 		const onSelect = jest.fn();
 
+		model.isComplete = true;
+
 		const { getByTestId, queryByTestId } = render(
 			<DownloadListItem
-				item={TEST_MODEL}
+				item={model}
 				index={0}
 				onSelect={onSelect}
 				onPlay={() => { /* no-op */ }}

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -28,6 +28,7 @@ describe('DownloadListItem', () => {
 				index={0}
 				onSelect={() => { /* no-op */ }}
 				onPlay={() => { /* no-op */ }}
+				onDelete={() => { /* no-op */ }}
 			/>
 		);
 
@@ -36,12 +37,13 @@ describe('DownloadListItem', () => {
 		expect(getByTestId('title')).toHaveTextContent('title');
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
 
-		expect(queryByTestId('play-button')).toBeNull();
+		expect(queryByTestId('menu-button')).toBeNull();
 		expect(queryByTestId('loading-indicator')).not.toBeNull();
 	});
 
-	it('should display the play button and handle presses', () => {
+	it('should display the menu and handle presses', () => {
 		const onPlay = jest.fn();
+		const onDelete = jest.fn();
 
 		TEST_MODEL.isComplete = true;
 
@@ -51,6 +53,7 @@ describe('DownloadListItem', () => {
 				index={0}
 				onSelect={() => { /* no-op */ }}
 				onPlay={onPlay}
+				onDelete={onDelete}
 			/>
 		);
 
@@ -59,12 +62,22 @@ describe('DownloadListItem', () => {
 		expect(getByTestId('title')).toHaveTextContent('title');
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
 
-		expect(queryByTestId('play-button')).not.toBeNull();
+		expect(queryByTestId('menu-button')).not.toBeNull();
 		expect(queryByTestId('loading-indicator')).toBeNull();
 
+		// Pressing the list item should call onPlay when not editing
 		expect(onPlay).not.toHaveBeenCalled();
-		fireEvent.press(getByTestId('play-button'));
-		expect(onPlay).toHaveBeenCalled();
+		fireEvent.press(getByTestId('list-item'));
+		expect(onPlay).toHaveBeenCalledTimes(1);
+		// Pressing the play menu action should call onPlay
+		expect(queryByTestId('play_in_app')).not.toBeNull();
+		fireEvent.press(getByTestId('play_in_app'));
+		expect(onPlay).toHaveBeenCalledTimes(2);
+		// Pressing the delete menu action should call onDelete
+		expect(onDelete).not.toHaveBeenCalled();
+		expect(queryByTestId('delete')).not.toBeNull();
+		fireEvent.press(getByTestId('delete'));
+		expect(onDelete).toHaveBeenCalled();
 	});
 
 	it('should display the select checkbox and handle presses', () => {
@@ -85,11 +98,15 @@ describe('DownloadListItem', () => {
 		expect(getByTestId('title')).toHaveTextContent('title');
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
 
-		expect(queryByTestId('play-button')).not.toBeNull();
+		expect(queryByTestId('menu-button')).not.toBeNull();
 		expect(queryByTestId('loading-indicator')).toBeNull();
 
 		expect(onSelect).not.toHaveBeenCalled();
+
+		// Pressing the list item and checkbox should call select
+		fireEvent.press(getByTestId('list-item'));
+		expect(onSelect).toHaveBeenCalledTimes(1);
 		fireEvent.press(getByTestId('select-checkbox'));
-		expect(onSelect).toHaveBeenCalled();
+		expect(onSelect).toHaveBeenCalledTimes(2);
 	});
 });

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -257,6 +257,8 @@ PODS:
     - glog
   - react-native-get-random-values (1.8.0):
     - React-Core
+  - react-native-menu (1.2.4):
+    - React
   - react-native-safe-area-context (4.3.1):
     - RCT-Folly
     - RCTRequired
@@ -437,6 +439,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
+  - "react-native-menu (from `../node_modules/@react-native-menu/menu`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -533,6 +536,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   react-native-get-random-values:
     :path: "../node_modules/react-native-get-random-values"
+  react-native-menu:
+    :path: "../node_modules/@react-native-menu/menu"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-webview:
@@ -611,6 +616,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 5b92a5a30e02e1a21802f293cc71e05d887c7378
   React-logger: 52038e064f4ec6897bd820f3bdcc09d2d7aa40bb
   react-native-get-random-values: 0fd2b6a3129988d701d10e30f0622d5f039531bc
+  react-native-menu: 475e400d9b57949c076a0844e130044b45f2aa3d
   react-native-safe-area-context: 3147a84d005125c9b38b59a32807db4bb28115b0
   react-native-webview: 5c84c9e56ab8cdfc211da7d59fa038a9ceed9738
   React-perflogger: f6f4b3c63629ead2e8a5a22eaedd06368c31617a

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,9 @@
 /**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 // import '@testing-library/jest-dom'
@@ -57,3 +59,36 @@ jest.mock('uuid', () => {
 		v4: () => `uuid-${value++}`
 	};
 });
+
+/* React Native Menu Mocks */
+jest.mock('@react-native-menu/menu', () => ({
+	MenuView: jest.fn((props) => {
+		const React = require('react');
+
+		class MockMenuView extends React.Component {
+			render() {
+				return React.createElement(
+					'View',
+					{ testID: props.testID },
+					// Dynamically mock each action
+					props.actions.map(action =>
+						React.createElement('Button', {
+							key: action.id,
+							title: action.title,
+							onPress: () => {
+								if (action.id && props?.onPressAction) {
+									props.onPressAction({ nativeEvent: { event: action.id } });
+								}
+							},
+							testID: action.id
+						})
+					),
+					// eslint-disable-next-line react/prop-types
+					this.props.children
+				);
+			}
+		}
+
+		return React.createElement(MockMenuView, props);
+	})
+}));

--- a/langs/en.json
+++ b/langs/en.json
@@ -5,6 +5,7 @@
     "delete": "Delete",
     "edit": "Edit",
     "ok": "OK",
+    "play": "Play",
     "unknown": "Unknown"
   },
   "headings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3317,6 +3317,12 @@
       "integrity": "sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw==",
       "requires": {}
     },
+    "@react-native-menu/menu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@react-native-menu/menu/-/menu-1.2.4.tgz",
+      "integrity": "sha512-63NU9NHd/KcBa7lhhV69xQmY3ORUxjMRmlzTY/qrY56GHnuKX+16dvUpKAuRSPK5kebBuRw5X4MFe2L9JHUlWA==",
+      "requires": {}
+    },
     "@react-native/assets": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/assets/-/assets-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@jellyfin/ux-ios": "1.0.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/masked-view": "0.1.11",
+    "@react-native-menu/menu": "1.2.4",
     "@react-navigation/bottom-tabs": "6.6.1",
     "@react-navigation/native": "6.1.18",
     "@react-navigation/native-stack": "6.11.0",

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -131,10 +131,12 @@ const DownloadScreen = () => {
 							item={item}
 							index={index}
 							isEditMode={isEditMode}
-							isSelected={selectedItems.includes(item)}
+							isSelected={selectedItems.some(s => s.key === item.key)}
 							onSelect={() => {
 								setSelectedItems(prev => (
-									prev.includes(item) ? prev.filter(s => s !== item) : [ ...prev, item ]
+									prev.some(s => s.key === item.key)
+										? prev.filter(s => s.key !== item.key)
+										: [ ...prev, item ]
 								));
 							}}
 							onPlay={() => {
@@ -151,7 +153,7 @@ const DownloadScreen = () => {
 							}}
 						/>
 					)}
-					keyExtractor={(item, index) => `download-${index}-${item.key}`}
+					keyExtractor={item => `download-${item.key}`}
 					contentContainerStyle={styles.listContainer}
 				/>
 			) : (

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -100,7 +100,7 @@ const DownloadScreen = () => {
 					/>
 			)
 		});
-	}, [ navigation, isEditMode, onDeleteItems, selectedItems, downloadStore.downloads ]);
+	}, [ navigation, isEditMode, onDeleteItems, selectedItems, downloadStore.downloads, t ]);
 
 	useFocusEffect(
 		useCallback(() => {
@@ -133,11 +133,9 @@ const DownloadScreen = () => {
 							isEditMode={isEditMode}
 							isSelected={selectedItems.includes(item)}
 							onSelect={() => {
-								if (selectedItems.includes(item)) {
-									setSelectedItems(selectedItems.filter(selected => selected !== item));
-								} else {
-									setSelectedItems([ ...selectedItems, item ]);
-								}
+								setSelectedItems(prev => (
+									prev.includes(item) ? prev.filter(s => s !== item) : [ ...prev, item ]
+								));
 							}}
 							onPlay={() => {
 								item.isNew = false;

--- a/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
@@ -202,6 +202,8 @@ exports[`DownloadScreen should render correctly 1`] = `
               }
             >
               <Text
+                ellipsizeMode="tail"
+                numberOfLines={1}
                 style={
                   Object {
                     "backgroundColor": "transparent",
@@ -214,6 +216,8 @@ exports[`DownloadScreen should render correctly 1`] = `
                 title
               </Text>
               <Text
+                ellipsizeMode="tail"
+                numberOfLines={1}
                 style={
                   Object {
                     "backgroundColor": "transparent",
@@ -342,6 +346,8 @@ exports[`DownloadScreen should render correctly 1`] = `
               }
             >
               <Text
+                ellipsizeMode="tail"
+                numberOfLines={1}
                 style={
                   Object {
                     "backgroundColor": "transparent",
@@ -354,6 +360,8 @@ exports[`DownloadScreen should render correctly 1`] = `
                 other title
               </Text>
               <Text
+                ellipsizeMode="tail"
+                numberOfLines={1}
                 style={
                   Object {
                     "backgroundColor": "transparent",

--- a/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
@@ -102,7 +102,18 @@ exports[`DownloadScreen should render correctly 1`] = `
         onLayout={[Function]}
         style={null}
       >
-        <View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          testID="list-item"
+        >
           <View
             style={
               Object {
@@ -232,7 +243,18 @@ exports[`DownloadScreen should render correctly 1`] = `
         onLayout={[Function]}
         style={null}
       >
-        <View>
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          testID="list-item"
+        >
           <View
             style={
               Object {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3bd00ae0-9531-492d-a217-7fd4885b4cfa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-item menu for completed downloads with Play and Delete actions (titles localized); tapping item plays in normal mode and selects in edit mode; added per-item Delete callback.

* **Refactor**
  * Replaced inline play button with menu-driven actions; unified list-item press behavior; single-line truncation for completed items.

* **Chores**
  * Added menu dependency and test mock.

* **Tests**
  * Updated tests to cover menu interactions, play/delete actions, and select-mode behavior.

* **Localization**
  * Added "Play" translation entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #372 