### PR TITLE
Update experimental download label

### DIFF
--- a/screens/DevSettingsScreen.js
+++ b/screens/DevSettingsScreen.js
@@ -44,7 +44,7 @@ const DevSettingsScreen = () => {
 					},
 					{
 						key: 'experimental-downloads-switch',
-						title: 'File Download Support',
+						title: 'Transcoded Downloads',
 						badge: {
 							value: 'Experimental',
 							status: 'error'

--- a/screens/__tests__/__snapshots__/DevSettingsScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DevSettingsScreen.test.js.snap
@@ -40,7 +40,7 @@ exports[`DevSettingsScreen should render correctly 1`] = `
           },
           "key": "experimental-downloads-switch",
           "onValueChange": [Function],
-          "title": "File Download Support",
+          "title": "Transcoded Downloads",
           "value": false,
         },
       ]
@@ -348,7 +348,7 @@ exports[`DevSettingsScreen should render correctly 1`] = `
                   }
                   testID="title"
                 >
-                  File Download Support
+                  Transcoded Downloads
                 </Text>
                 <View
                   style={


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Renamed the Developer Settings toggle from “File Download Support” to “Transcoded Downloads” for clearer wording.
  - This is a text-only change: functionality, default state, and behavior are unchanged.
  - Toggling the switch will still prompt an app reload, as before.
  - Aims to better communicate that downloaded media is transcoded rather than raw files, with no impact on existing settings or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->