### PR TITLE
Use theme setting for download menu

### DIFF
--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { ActivityIndicator } from 'react-native';
 import { Button, ListItem } from 'react-native-elements';
 
+import { useStores } from '../hooks/useStores';
 import type DownloadModel from '../models/DownloadModel';
 
 interface DownloadListItemProps {
@@ -38,6 +39,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	isEditMode = false,
 	isSelected = false
 }) => {
+	const { settingStore } = useStores();
 	const { t } = useTranslation();
 
 	const menuActions = useMemo(() => [
@@ -107,7 +109,9 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 					actions={menuActions}
 					onPressAction={onMenuPress}
 					shouldOpenOnLongPress={false}
-					themeVariant='dark'
+					themeVariant={
+						settingStore.getTheme().dark ? 'dark' : 'light'
+					}
 				>
 					<Button
 						testID='menu-button'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * The menu in Download items now automatically adapts to your selected app theme (light or dark), delivering consistent visuals across the app.

* Style
  * Refined the menu appearance for completed downloads to align with the active theme, improving readability and cohesion.
  * No changes to edit-mode checkboxes or loading indicators; existing behaviors remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->