### PR TITLE
Fix number format crash

### DIFF
--- a/utils/profiles/base.ts
+++ b/utils/profiles/base.ts
@@ -14,9 +14,9 @@ import { SubtitleDeliveryMethod } from '@jellyfin/sdk/lib/generated-client/model
 
 const BaseProfile = {
 	Name: 'Expo Base Video Profile',
-	MaxStaticBitrate: 100_000_000, // 100 Mbps
-	MaxStreamingBitrate: 120_000_000, // 120 Mbps
-	MusicStreamingTranscodingBitrate: 384_000, // 384 kbps
+	MaxStaticBitrate: 100000000, // 100 Mbps
+	MaxStreamingBitrate: 120000000, // 120 Mbps
+	MusicStreamingTranscodingBitrate: 384000, // 384 kbps
 	CodecProfiles: [
 		{
 			Codec: 'h264',


### PR DESCRIPTION
Using underscores in number literals is not supported in older OS versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized numeric literal formatting in bitrate configurations by removing underscore separators for consistency. This is a cosmetic update only; functionality, performance, and behavior remain unchanged.

- Chores
  - Minor cleanup with no modifications to public interfaces or settings. Playback, streaming, and transcoding continue to operate exactly as before. No tests or documentation updates required, and no action is needed from users or administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->