### PR TITLE
Fix pressing download list item when incomplete

### DIFF
--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -58,6 +58,15 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 		}
 	], [ t ]);
 
+	const onItemPress = useCallback(() => {
+		// Do nothing if the download is incomplete
+		if (!item.isComplete) return;
+		// Call select callback if in edit mode
+		if (isEditMode) onSelect();
+		// Otherwise call play callback
+		else onPlay();
+	}, [ isEditMode, item.isComplete, onPlay, onSelect ]);
+
 	const onMenuPress = useCallback(({ nativeEvent }: NativeActionEvent) => {
 		switch (nativeEvent.event) {
 			case MenuAction.PlayInApp:
@@ -74,10 +83,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			testID='list-item'
 			topDivider={index === 0}
 			bottomDivider
-			onPress={() => {
-				if (isEditMode) onSelect();
-				else onPlay();
-			}}
+			onPress={onItemPress}
 		>
 			{isEditMode &&
 			<ListItem.CheckBox

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -59,13 +59,11 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	], [ t ]);
 
 	const onItemPress = useCallback(() => {
-		// Do nothing if the download is incomplete
-		if (!item.isComplete) return;
 		// Call select callback if in edit mode
 		if (isEditMode) onSelect();
 		// Otherwise call play callback
 		else onPlay();
-	}, [ isEditMode, item.isComplete, onPlay, onSelect ]);
+	}, [ isEditMode, onPlay, onSelect ]);
 
 	const onMenuPress = useCallback(({ nativeEvent }: NativeActionEvent) => {
 		switch (nativeEvent.event) {
@@ -83,7 +81,8 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			testID='list-item'
 			topDivider={index === 0}
 			bottomDivider
-			onPress={onItemPress}
+			onPress={item.isComplete ? onItemPress : undefined}
+			accessibilityState={{ disabled: !item.isComplete }}
 		>
 			{isEditMode &&
 			<ListItem.CheckBox

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -28,12 +28,15 @@ describe('DownloadListItem', () => {
 	});
 
 	it('should render correctly', () => {
+		const onPlay = jest.fn();
+		const onSelect = jest.fn();
+
 		const { getByTestId, queryByTestId } = render(
 			<DownloadListItem
 				item={model}
 				index={0}
-				onSelect={() => { /* no-op */ }}
-				onPlay={() => { /* no-op */ }}
+				onSelect={onSelect}
+				onPlay={onPlay}
 				onDelete={() => { /* no-op */ }}
 			/>
 		);
@@ -45,6 +48,11 @@ describe('DownloadListItem', () => {
 
 		expect(queryByTestId('menu-button')).toBeNull();
 		expect(queryByTestId('loading-indicator')).not.toBeNull();
+
+		// Pressing the list item and checkbox should call select
+		fireEvent.press(getByTestId('list-item'));
+		expect(onPlay).not.toHaveBeenCalled();
+		expect(onSelect).not.toHaveBeenCalled();
 	});
 
 	it('should display the menu and handle presses', () => {

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -48,11 +48,6 @@ describe('DownloadListItem', () => {
 
 		expect(queryByTestId('menu-button')).toBeNull();
 		expect(queryByTestId('loading-indicator')).not.toBeNull();
-
-		// Pressing the list item and checkbox should call select
-		fireEvent.press(getByTestId('list-item'));
-		expect(onPlay).not.toHaveBeenCalled();
-		expect(onSelect).not.toHaveBeenCalled();
 	});
 
 	it('should display the menu and handle presses', () => {

--- a/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
@@ -111,15 +111,11 @@ exports[`DownloadScreen should render correctly 1`] = `
         style={null}
       >
         <View
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
           testID="list-item"
         >
           <View
@@ -256,15 +252,11 @@ exports[`DownloadScreen should render correctly 1`] = `
         style={null}
       >
         <View
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
           testID="list-item"
         >
           <View


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Tapping a download item now behaves consistently: incomplete items are disabled/no-op; in edit mode tapping selects the item; otherwise tapping starts playback. Menu actions remain unchanged.
- Tests
  - Updated tests to verify tap behavior for complete, incomplete, and edit-mode items to prevent unintended playback or selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->