### PR TITLE
Update download item subtitles

### DIFF
--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -59,6 +59,8 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 		}
 	], [ t ]);
 
+	const subtitle = useMemo(() => item.item && getItemSubtitle(item.item), [ item.item ]);
+
 	const onItemPress = useCallback(() => {
 		// Call select callback if in edit mode
 		if (isEditMode) onSelect();
@@ -108,7 +110,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 					numberOfLines={1}
 					ellipsizeMode='tail'
 				>
-					{getItemSubtitle(item.item) || item.localFilename}
+					{subtitle || item.localFilename}
 				</ListItem.Subtitle>
 			</ListItem.Content>
 			{item.isComplete ? (

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -14,6 +14,7 @@ import { Button, ListItem } from 'react-native-elements';
 
 import { useStores } from '../hooks/useStores';
 import type DownloadModel from '../models/DownloadModel';
+import { getItemSubtitle } from '../utils/baseItem';
 
 interface DownloadListItemProps {
 	item: DownloadModel;
@@ -107,7 +108,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 					numberOfLines={1}
 					ellipsizeMode='tail'
 				>
-					{item.localFilename}
+					{getItemSubtitle(item.item) || item.localFilename}
 				</ListItem.Subtitle>
 			</ListItem.Content>
 			{item.isComplete ? (

--- a/utils/__tests__/baseItem.test.js
+++ b/utils/__tests__/baseItem.test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { getItemSubtitle } from '../baseItem';
+
+describe('getItemSubtitle', () => {
+	it('should handle episodes correctly', () => {
+		const item = {
+			SeriesName: 'Series Name'
+		};
+		expect(getItemSubtitle(item)).toBe('Series Name');
+
+		item.ParentIndexNumber = 5;
+		expect(getItemSubtitle(item)).toBe('Series Name S5');
+
+		item.IndexNumber = 11;
+		expect(getItemSubtitle(item)).toBe('Series Name S5E11');
+
+		item.IndexNumberEnd = 13;
+		expect(getItemSubtitle(item)).toBe('Series Name S5E11-13');
+
+		delete item.ParentIndexNumber;
+		delete item.IndexNumberEnd;
+		expect(getItemSubtitle(item)).toBe('Series Name E11');
+	});
+
+	it('should handle songs correctly', () => {
+		const item = {
+			Album: 'Album Name'
+		};
+		expect(getItemSubtitle(item)).toBe('Album Name');
+
+		item.AlbumArtist = 'Artist Name';
+		expect(getItemSubtitle(item)).toBe('Artist Name · Album Name');
+	});
+
+	it('should fallback to production year for other types', () => {
+		const item = { ProductionYear: 2025 };
+		expect(getItemSubtitle(item)).toBe('2025');
+	});
+});

--- a/utils/__tests__/baseItem.test.js
+++ b/utils/__tests__/baseItem.test.js
@@ -27,6 +27,10 @@ describe('getItemSubtitle', () => {
 		delete item.ParentIndexNumber;
 		delete item.IndexNumberEnd;
 		expect(getItemSubtitle(item)).toBe('Series Name E11');
+
+		item.ParentIndexNumber = 0;
+		item.IndexNumber = 0;
+		expect(getItemSubtitle(item)).toBe('Series Name S0E0');
 	});
 
 	it('should handle songs correctly', () => {
@@ -42,5 +46,9 @@ describe('getItemSubtitle', () => {
 	it('should fallback to production year for other types', () => {
 		const item = { ProductionYear: 2025 };
 		expect(getItemSubtitle(item)).toBe('2025');
+	});
+
+	it('should return undefined when production year is unavailable', () => {
+		expect(getItemSubtitle({})).toBeUndefined();
 	});
 });

--- a/utils/baseItem.ts
+++ b/utils/baseItem.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
+
+export const getItemSubtitle = (item: BaseItemDto) => {
+	// Episodes will show: Series Name S1E5-6
+	if (item.SeriesName) {
+		let episode = '';
+		if (item.ParentIndexNumber) episode += `S${item.ParentIndexNumber}`;
+		if (item.IndexNumber) episode += `E${item.IndexNumber}`;
+		if (item.IndexNumberEnd) episode += `-${item.IndexNumberEnd}`;
+		return episode ? `${item.SeriesName} ${episode}` : item.SeriesName;
+	}
+
+	// Songs will show: Artist Name · Album Name
+	if (item.Album) {
+		return [
+			item.AlbumArtist,
+			item.Album
+		]
+			.filter(t => !!t)
+			.join(' · ');
+	}
+
+	// Everything else will show the production year or fallback to the filename for legacy downloads
+	return item.ProductionYear?.toString();
+};

--- a/utils/baseItem.ts
+++ b/utils/baseItem.ts
@@ -8,13 +8,19 @@
 
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
 
-export const getItemSubtitle = (item: BaseItemDto) => {
+export const getItemSubtitle = (item: BaseItemDto): string | undefined => {
 	// Episodes will show: Series Name S1E5-6
 	if (item.SeriesName) {
 		let episode = '';
-		if (item.ParentIndexNumber) episode += `S${item.ParentIndexNumber}`;
-		if (item.IndexNumber) episode += `E${item.IndexNumber}`;
-		if (item.IndexNumberEnd) episode += `-${item.IndexNumberEnd}`;
+		if (typeof item.ParentIndexNumber !== 'undefined') {
+			episode += `S${item.ParentIndexNumber}`;
+		}
+		if (typeof item.IndexNumber !== 'undefined') {
+			episode += `E${item.IndexNumber}`;
+			if (typeof item.IndexNumberEnd !== 'undefined') {
+				episode += `-${item.IndexNumberEnd}`;
+			}
+		}
 		return episode ? `${item.SeriesName} ${episode}` : item.SeriesName;
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Download list items now show smarter subtitles: episodes display series name with season/episode or episode-range when available, music shows "Artist · Album," and other items show production year. Falls back to the local filename when no metadata is present.

- Tests
  - Added unit tests validating subtitle generation for episode formats (including ranges), songs (artist and album), and fallbacks to production year, ensuring consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->