### PR TITLE
Fix resuming playback when exiting picture-in-picture

### DIFF
--- a/components/VideoPlayer.js
+++ b/components/VideoPlayer.js
@@ -109,14 +109,17 @@ const VideoPlayer = () => {
 						setIsPresenting(true);
 						rootStore.set({ isFullscreen: true });
 						break;
-                                        case VideoFullscreenUpdate.PLAYER_DID_PRESENT:
-                                                setIsPresenting(false);
-                                                if (!mediaStore.isPlaying) {
-                                                        player.current?.playAsync()
-                                                                .catch(console.debug);
-                                                }
-                                                break;
-                                        case VideoFullscreenUpdate.PLAYER_WILL_DISMISS:
+					case VideoFullscreenUpdate.PLAYER_DID_PRESENT:
+						setIsPresenting(false);
+						if (!mediaStore.isPlaying) {
+							const current = player.current;
+							if (current) {
+								const playPromise = current.playAsync();
+								playPromise.catch(console.debug);
+							}
+						}
+						break;
+					case VideoFullscreenUpdate.PLAYER_WILL_DISMISS:
 						setIsDismissing(true);
 						break;
 					case VideoFullscreenUpdate.PLAYER_DID_DISMISS:

--- a/components/VideoPlayer.js
+++ b/components/VideoPlayer.js
@@ -109,10 +109,14 @@ const VideoPlayer = () => {
 						setIsPresenting(true);
 						rootStore.set({ isFullscreen: true });
 						break;
-					case VideoFullscreenUpdate.PLAYER_DID_PRESENT:
-						setIsPresenting(false);
-						break;
-					case VideoFullscreenUpdate.PLAYER_WILL_DISMISS:
+                                        case VideoFullscreenUpdate.PLAYER_DID_PRESENT:
+                                                setIsPresenting(false);
+                                                if (!mediaStore.isPlaying) {
+                                                        player.current?.playAsync()
+                                                                .catch(console.debug);
+                                                }
+                                                break;
+                                        case VideoFullscreenUpdate.PLAYER_WILL_DISMISS:
 						setIsDismissing(true);
 						break;
 					case VideoFullscreenUpdate.PLAYER_DID_DISMISS:


### PR DESCRIPTION
### Summary
- Ensure the player checks its current status on fullscreen restore and resumes playback automatically if it isn't already running

### Testing
- `npm test -- -i --watchAll=false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Video playback now automatically resumes when entering fullscreen, preventing pauses or stalls and ensuring a smoother transition experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #289 