### PR TITLE
Fix menu support for iOS 12

### DIFF
--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -6,7 +6,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { type NativeActionEvent } from '@react-native-menu/menu';
 import React, { useCallback, useMemo, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator } from 'react-native';
@@ -17,6 +16,7 @@ import type DownloadModel from '../models/DownloadModel';
 import { getItemSubtitle } from '../utils/baseItem';
 
 import MenuViewButton from './MenuViewButton';
+import type { MenuPressEvent } from './MenuViewButton/types';
 
 interface DownloadListItemProps {
 	item: DownloadModel;
@@ -70,7 +70,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 		else onPlay();
 	}, [ isEditMode, onPlay, onSelect ]);
 
-	const onMenuPress = useCallback(({ nativeEvent }: NativeActionEvent) => {
+	const onMenuPress = useCallback(({ nativeEvent }: MenuPressEvent) => {
 		switch (nativeEvent.event) {
 			case MenuAction.PlayInApp:
 				return onPlay();

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -6,15 +6,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { MenuView, type NativeActionEvent } from '@react-native-menu/menu';
+import { type NativeActionEvent } from '@react-native-menu/menu';
 import React, { useCallback, useMemo, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator } from 'react-native';
-import { Button, ListItem } from 'react-native-elements';
+import { ListItem } from 'react-native-elements';
 
 import { useStores } from '../hooks/useStores';
 import type DownloadModel from '../models/DownloadModel';
 import { getItemSubtitle } from '../utils/baseItem';
+
+import MenuViewButton from './MenuViewButton';
 
 interface DownloadListItemProps {
 	item: DownloadModel;
@@ -114,7 +116,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 				</ListItem.Subtitle>
 			</ListItem.Content>
 			{item.isComplete ? (
-				<MenuView
+				<MenuViewButton
 					testID='menu-view'
 					actions={menuActions}
 					onPressAction={onMenuPress}
@@ -122,17 +124,8 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 					themeVariant={
 						settingStore.getTheme().dark ? 'dark' : 'light'
 					}
-				>
-					<Button
-						testID='menu-button'
-						type='clear'
-						icon={{
-							name: 'ellipsis-horizontal',
-							type: 'ionicon'
-						}}
-						disabled={isEditMode}
-					/>
-				</MenuView>
+					disabled={isEditMode}
+				/>
 			) :
 				<ActivityIndicator testID='loading-indicator' />
 			}

--- a/components/MenuViewButton/index.ios.tsx
+++ b/components/MenuViewButton/index.ios.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { MenuView } from '@react-native-menu/menu';
+import compareVersions from 'compare-versions';
+import React, { useCallback, type FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ActionSheetIOS, Platform } from 'react-native';
+import { Button } from 'react-native-elements';
+
+import type { MenuViewButtonProps } from './types';
+
+const isMenuSupported = !Platform.Version // Version is undefined in tests
+	|| compareVersions.compare(String(Platform.Version), '13', '>=');
+
+/**
+ * A Button component that opens a MenuView with fallback to Action Sheet for iOS 12.
+ */
+const MenuViewButton: FC<MenuViewButtonProps> = ({
+	disabled,
+	...menuProps
+}) => {
+	const { t } = useTranslation();
+
+	const onPress = useCallback(() => {
+		if (isMenuSupported) return;
+
+		ActionSheetIOS.showActionSheetWithOptions(
+			{
+				options: [
+					...menuProps.actions.map(a => a.title),
+					t('common.cancel')
+				],
+				destructiveButtonIndex: menuProps.actions.findIndex(a => a.attributes?.destructive),
+				cancelButtonIndex: menuProps.actions.length,
+				userInterfaceStyle: menuProps.themeVariant
+			},
+			index => {
+				const action = menuProps.actions[index];
+				if (!action) return;
+
+				return menuProps.onPressAction?.({
+					nativeEvent: {
+						event: action.id || action.title
+					}
+				});
+			}
+		);
+	}, [ t ]);
+
+	const button = (
+		<Button
+			type='clear'
+			icon={{
+				name: 'ellipsis-horizontal',
+				type: 'ionicon'
+			}}
+			disabled={disabled}
+			onPress={onPress}
+		/>
+	);
+
+	if (isMenuSupported) {
+		return (
+			<MenuView {...menuProps}>
+				{button}
+			</MenuView>
+		);
+	}
+
+	return button;
+};
+
+MenuViewButton.displayName = 'MenuViewButton';
+export default MenuViewButton;

--- a/components/MenuViewButton/index.ios.tsx
+++ b/components/MenuViewButton/index.ios.tsx
@@ -28,20 +28,22 @@ const MenuViewButton: FC<MenuViewButtonProps> = ({
 	const { t } = useTranslation();
 
 	const onPress = useCallback(() => {
-		if (isMenuSupported) return;
+		if (isMenuSupported || disabled) return;
+		const actions = menuProps.actions || [];
+		if (!actions.length) return;
 
 		ActionSheetIOS.showActionSheetWithOptions(
 			{
 				options: [
-					...menuProps.actions.map(a => a.title),
+					...actions.map(a => a.title),
 					t('common.cancel')
 				],
-				destructiveButtonIndex: menuProps.actions.findIndex(a => a.attributes?.destructive),
-				cancelButtonIndex: menuProps.actions.length,
+				destructiveButtonIndex: actions.findIndex(a => a.attributes?.destructive),
+				cancelButtonIndex: actions.length,
 				userInterfaceStyle: menuProps.themeVariant
 			},
 			index => {
-				const action = menuProps.actions[index];
+				const action = actions[index];
 				if (!action) return;
 
 				return menuProps.onPressAction?.({
@@ -51,7 +53,7 @@ const MenuViewButton: FC<MenuViewButtonProps> = ({
 				});
 			}
 		);
-	}, [ t ]);
+	}, [ disabled, menuProps.actions, menuProps.onPressAction, menuProps.themeVariant, t ]);
 
 	const button = (
 		<Button

--- a/components/MenuViewButton/index.tsx
+++ b/components/MenuViewButton/index.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { MenuView } from '@react-native-menu/menu';
+import React, { type FC } from 'react';
+import { Button } from 'react-native-elements';
+
+import type { MenuViewButtonProps } from './types';
+
+/**
+ * A Button component that opens a MenuView with fallback to Action Sheet for iOS 12.
+ */
+const MenuViewButton: FC<MenuViewButtonProps> = ({
+	disabled,
+	...menuProps
+}) => {
+	return (
+		<MenuView {...menuProps}>
+			<Button
+				type='clear'
+				icon={{
+					name: 'ellipsis-horizontal',
+					type: 'ionicon'
+				}}
+				disabled={disabled}
+				onPress={() => { /* no-op */ }}
+			/>
+		</MenuView>
+	);
+};
+
+MenuViewButton.displayName = 'MenuViewButton';
+export default MenuViewButton;

--- a/components/MenuViewButton/types.ts
+++ b/components/MenuViewButton/types.ts
@@ -6,9 +6,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import type { MenuComponentProps } from '@react-native-menu/menu';
+import type { MenuComponentProps, NativeActionEvent } from '@react-native-menu/menu';
+
+/** Event that is fired when a menu item is pressed. */
+export type MenuPressEvent = NativeActionEvent;
 
 export interface MenuViewButtonProps extends MenuComponentProps {
+	/** A narrowed type for MenuView and ActionSheet theming that only allows supported values. */
 	themeVariant?: 'light' | 'dark';
+	/** Disable the button (and effectively the menu). */
 	disabled?: boolean;
 }

--- a/components/MenuViewButton/types.ts
+++ b/components/MenuViewButton/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import type { MenuComponentProps } from '@react-native-menu/menu';
+
+export interface MenuViewButtonProps extends MenuComponentProps {
+	themeVariant?: 'light' | 'dark';
+	disabled?: boolean;
+}

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -14,6 +14,8 @@ describe('DownloadListItem', () => {
 	let model;
 
 	beforeEach(() => {
+		jest.resetModules();
+
 		model = new DownloadModel(
 			{
 				Id: 'item-id',
@@ -46,7 +48,6 @@ describe('DownloadListItem', () => {
 		expect(getByTestId('title')).toHaveTextContent('title');
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
 
-		expect(queryByTestId('menu-button')).toBeNull();
 		expect(queryByTestId('loading-indicator')).not.toBeNull();
 	});
 
@@ -71,7 +72,6 @@ describe('DownloadListItem', () => {
 		expect(getByTestId('title')).toHaveTextContent('title');
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
 
-		expect(queryByTestId('menu-button')).not.toBeNull();
 		expect(queryByTestId('loading-indicator')).toBeNull();
 
 		// Pressing the list item should call onPlay when not editing
@@ -109,7 +109,6 @@ describe('DownloadListItem', () => {
 		expect(getByTestId('title')).toHaveTextContent('title');
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
 
-		expect(queryByTestId('menu-button')).not.toBeNull();
 		expect(queryByTestId('loading-indicator')).toBeNull();
 
 		expect(onSelect).not.toHaveBeenCalled();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,11 @@
     "typeRoots": [
       "./types"
     ],
+    "moduleSuffixes": [
+      ".ios",
+      ".android",
+      ""
+    ],
     "noImplicitAny": true,
     "strict": true
   },


### PR DESCRIPTION
Fixes #693 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified menu button on downloaded items to play in-app or delete; menu disabled in edit mode.
  - Menu adapts to iOS version: native menu on modern iOS with action-sheet fallback on older versions.
  - Edit mode: tapping selects items and selection state is shown.
- Chores
  - Enabled platform-specific module resolution for .ios/.android variants.
- Tests
  - Adjusted tests to isolate modules and removed assertions around menu button presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->