### PR TITLE
Add enum for download status

### DIFF
--- a/App.js
+++ b/App.js
@@ -27,6 +27,7 @@ import { ThemeContext, ThemeProvider } from 'react-native-elements';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import ThemeSwitcher from './components/ThemeSwitcher';
+import { DownloadStatus } from './constants/DownloadStatus';
 import { useIsHydrated } from './hooks/useHydrated';
 import { useStores } from './hooks/useStores';
 import { fromStorageObject } from './models/DownloadModel';
@@ -213,11 +214,10 @@ const App = ({ skipLoadingScreen }) => {
 
 			// Download the file
 			try {
-				download.isDownloading = true;
+				download.status = DownloadStatus.Downloading;
 				downloadStore.update(download);
 				await resumable.downloadAsync();
-				download.isComplete = true;
-				download.isDownloading = false;
+				download.status = DownloadStatus.Complete;
 			} catch (e) {
 				console.error('[App] Download failed', e);
 				Alert.alert(
@@ -226,7 +226,7 @@ const App = ({ skipLoadingScreen }) => {
 				);
 
 				// TODO: If a download fails, we should probably remove it from the queue
-				download.isDownloading = false;
+				download.status = DownloadStatus.Failed;
 			}
 
 			// Push the state update to the store
@@ -249,7 +249,7 @@ const App = ({ skipLoadingScreen }) => {
 
 		downloadStore.downloads
 			.forEach(download => {
-				if (!download.isComplete && !download.isDownloading) {
+				if (download.status === DownloadStatus.Pending) {
 					downloadFile(download);
 				}
 			});

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -48,7 +48,6 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			topDivider={index === 0}
 			bottomDivider
 			onPress={item.isComplete ? onItemPress : undefined}
-			accessibilityState={{ disabled: !item.isComplete }}
 		>
 			{isEditMode &&
 				<ListItem.CheckBox

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -7,16 +7,12 @@
  */
 
 import React, { useCallback, useMemo, type FC } from 'react';
-import { useTranslation } from 'react-i18next';
-import { ActivityIndicator } from 'react-native';
 import { ListItem } from 'react-native-elements';
 
-import { useStores } from '../hooks/useStores';
 import type DownloadModel from '../models/DownloadModel';
 import { getItemSubtitle } from '../utils/baseItem';
 
-import MenuViewButton from './MenuViewButton';
-import type { MenuPressEvent } from './MenuViewButton/types';
+import DownloadStatusIndicator from './DownloadStatusIndicator';
 
 interface DownloadListItemProps {
 	item: DownloadModel;
@@ -28,11 +24,6 @@ interface DownloadListItemProps {
 	isSelected?: boolean;
 }
 
-const MenuAction = {
-	Delete: 'delete',
-	PlayInApp: 'play_in_app'
-} as const;
-
 const DownloadListItem: FC<DownloadListItemProps> = ({
 	item,
 	index,
@@ -42,25 +33,6 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	isEditMode = false,
 	isSelected = false
 }) => {
-	const { settingStore } = useStores();
-	const { t } = useTranslation();
-
-	const menuActions = useMemo(() => [
-		{
-			id: MenuAction.PlayInApp,
-			title: t('common.play'),
-			image: 'play'
-		},
-		{
-			id: MenuAction.Delete,
-			title: t('common.delete'),
-			attributes: {
-				destructive: true
-			},
-			image: 'trash'
-		}
-	], [ t ]);
-
 	const subtitle = useMemo(() => item.item && getItemSubtitle(item.item), [ item.item ]);
 
 	const onItemPress = useCallback(() => {
@@ -69,17 +41,6 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 		// Otherwise call play callback
 		else onPlay();
 	}, [ isEditMode, onPlay, onSelect ]);
-
-	const onMenuPress = useCallback(({ nativeEvent }: MenuPressEvent) => {
-		switch (nativeEvent.event) {
-			case MenuAction.PlayInApp:
-				return onPlay();
-			case MenuAction.Delete:
-				return onDelete();
-			default:
-				console.warn('[DownloadListItem.onMenuPress] unhandled menu press action', nativeEvent.event);
-		}
-	}, [ onDelete, onPlay ]);
 
 	return (
 		<ListItem
@@ -115,24 +76,16 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 					{subtitle || item.localFilename}
 				</ListItem.Subtitle>
 			</ListItem.Content>
-			{item.isComplete ? (
-				<MenuViewButton
-					testID='menu-view'
-					actions={menuActions}
-					onPressAction={onMenuPress}
-					shouldOpenOnLongPress={false}
-					themeVariant={
-						settingStore.getTheme().dark ? 'dark' : 'light'
-					}
-					disabled={isEditMode}
-				/>
-			) :
-				<ActivityIndicator testID='loading-indicator' />
-			}
+
+			<DownloadStatusIndicator
+				download={item}
+				isEditMode={isEditMode}
+				onDelete={onDelete}
+				onPlay={onPlay}
+			/>
 		</ListItem>
 	);
 };
 
 DownloadListItem.displayName = 'DownloadListItem';
-
 export default DownloadListItem;

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -89,6 +89,7 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 		case DownloadStatus.Failed:
 			return (
 				<Icon
+					testID='failed-icon'
 					type='ionicon'
 					name={getIconName('warning')}
 					color={theme.colors?.error}

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -14,8 +14,7 @@ import { Icon, ThemeContext } from 'react-native-elements';
 
 import { DownloadStatus } from '../constants/DownloadStatus';
 import { useStores } from '../hooks/useStores';
-import DownloadModel from '../models/DownloadModel';
-
+import type DownloadModel from '../models/DownloadModel';
 import { getIconName } from '../utils/Icons';
 
 import MenuViewButton from './MenuViewButton';

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useCallback, useContext, useMemo, type FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ActivityIndicator } from 'react-native';
+
+import { Icon, ThemeContext } from 'react-native-elements';
+
+import { DownloadStatus } from '../constants/DownloadStatus';
+import { useStores } from '../hooks/useStores';
+import DownloadModel from '../models/DownloadModel';
+
+import { getIconName } from '../utils/Icons';
+
+import MenuViewButton from './MenuViewButton';
+import { MenuPressEvent } from './MenuViewButton/types';
+
+interface DownloadStatusIndicatorProps {
+	download: DownloadModel;
+	isEditMode?: boolean;
+	onDelete: () => void;
+	onPlay: () => void;
+}
+
+const MenuAction = {
+	Delete: 'delete',
+	PlayInApp: 'play_in_app'
+} as const;
+
+const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
+	download,
+	isEditMode,
+	onDelete,
+	onPlay
+}) => {
+	const { settingStore } = useStores();
+	const { theme } = useContext(ThemeContext);
+	const { t } = useTranslation();
+
+	const menuActions = useMemo(() => [
+		{
+			id: MenuAction.PlayInApp,
+			title: t('common.play'),
+			image: 'play'
+		},
+		{
+			id: MenuAction.Delete,
+			title: t('common.delete'),
+			attributes: {
+				destructive: true
+			},
+			image: 'trash'
+		}
+	], [ t ]);
+
+	const onMenuPress = useCallback(({ nativeEvent }: MenuPressEvent) => {
+		switch (nativeEvent.event) {
+			case MenuAction.PlayInApp:
+				return onPlay();
+			case MenuAction.Delete:
+				return onDelete();
+			default:
+				console.warn('[DownloadStatusIndicator.onMenuPress] unhandled menu press action', nativeEvent.event);
+		}
+	}, [ onDelete, onPlay ]);
+
+	switch (download.status) {
+		case DownloadStatus.Complete:
+			return (
+				<MenuViewButton
+					testID='menu-view'
+					actions={menuActions}
+					onPressAction={onMenuPress}
+					shouldOpenOnLongPress={false}
+					themeVariant={
+						settingStore.getTheme().dark ? 'dark' : 'light'
+					}
+					disabled={isEditMode}
+				/>
+			);
+		case DownloadStatus.Downloading:
+			return <ActivityIndicator testID='loading-indicator' />;
+		case DownloadStatus.Failed:
+			return (
+				<Icon
+					type='ionicon'
+					name={getIconName('warning')}
+					color={theme.colors?.error}
+				/>
+			);
+		default:
+			return (
+				<Icon
+					type='ionicon'
+					name={getIconName('help-circle')}
+				/>
+			);
+	}
+};
+
+DownloadStatusIndicator.displayName = 'DownloadStatusIndicator';
+export default DownloadStatusIndicator;

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -35,7 +35,7 @@ const MenuAction = {
 
 const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	download,
-	isEditMode,
+	isEditMode = false,
 	onDelete,
 	onPlay
 }) => {

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -7,6 +7,7 @@
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
+import { DownloadStatus } from '../../constants/DownloadStatus';
 import DownloadModel from '../../models/DownloadModel';
 import DownloadListItem from '../DownloadListItem';
 
@@ -33,6 +34,8 @@ describe('DownloadListItem', () => {
 		const onPlay = jest.fn();
 		const onSelect = jest.fn();
 
+		model.status = DownloadStatus.Downloading;
+
 		const { getByTestId, queryByTestId } = render(
 			<DownloadListItem
 				item={model}
@@ -55,7 +58,7 @@ describe('DownloadListItem', () => {
 		const onPlay = jest.fn();
 		const onDelete = jest.fn();
 
-		model.isComplete = true;
+		model.status = DownloadStatus.Complete;
 
 		const { getByTestId, queryByTestId } = render(
 			<DownloadListItem
@@ -92,7 +95,7 @@ describe('DownloadListItem', () => {
 	it('should display the select checkbox and handle presses', () => {
 		const onSelect = jest.fn();
 
-		model.isComplete = true;
+		model.status = DownloadStatus.Complete;
 
 		const { getByTestId, queryByTestId } = render(
 			<DownloadListItem

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -47,6 +47,7 @@ describe('DownloadListItem', () => {
 		);
 
 		expect(queryByTestId('select-checkbox')).toBeNull();
+		expect(queryByTestId('failed-icon')).toBeNull();
 
 		expect(getByTestId('title')).toHaveTextContent('title');
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
@@ -71,6 +72,7 @@ describe('DownloadListItem', () => {
 		);
 
 		expect(queryByTestId('select-checkbox')).toBeNull();
+		expect(queryByTestId('failed-icon')).toBeNull();
 
 		expect(getByTestId('title')).toHaveTextContent('title');
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
@@ -113,6 +115,7 @@ describe('DownloadListItem', () => {
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
 
 		expect(queryByTestId('loading-indicator')).toBeNull();
+		expect(queryByTestId('failed-icon')).toBeNull();
 
 		expect(onSelect).not.toHaveBeenCalled();
 
@@ -121,5 +124,27 @@ describe('DownloadListItem', () => {
 		expect(onSelect).toHaveBeenCalledTimes(1);
 		fireEvent.press(getByTestId('select-checkbox'));
 		expect(onSelect).toHaveBeenCalledTimes(2);
+	});
+
+	it('should display a warning for failed downloads', () => {
+		model.status = DownloadStatus.Failed;
+
+		const { getByTestId, queryByTestId } = render(
+			<DownloadListItem
+				item={model}
+				index={0}
+				onSelect={jest.fn()}
+				onPlay={jest.fn()}
+				onDelete={jest.fn()}
+			/>
+		);
+
+		expect(queryByTestId('select-checkbox')).toBeNull();
+		expect(queryByTestId('loading-indicator')).toBeNull();
+
+		expect(getByTestId('title')).toHaveTextContent('title');
+		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
+
+		expect(queryByTestId('failed-icon')).not.toBeNull();
 	});
 });

--- a/constants/DownloadStatus.ts
+++ b/constants/DownloadStatus.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/** The different statuses a download can be in. */
+export const DownloadStatus = {
+	/** The download is complete. */
+	Complete: 'complete',
+	/** The download is in progress. */
+	Downloading: 'downloading',
+	/** The download has failed. */
+	Failed: 'failed',
+	/** The download is missing (has been deleted from storage). */
+	Missing: 'missing',
+	/** The download is pending download. */
+	Pending: 'pending'
+} as const;
+
+export type DownloadStatus = typeof DownloadStatus[keyof typeof DownloadStatus];

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -10,6 +10,8 @@ import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base
 import * as FileSystem from 'expo-file-system';
 import { v4 as uuidv4 } from 'uuid';
 
+import { DownloadStatus } from '../constants/DownloadStatus';
+
 export interface DownloadItem extends BaseItemDto {
 	Id: string;
 	ServerId: string;
@@ -28,8 +30,7 @@ interface MobxDownloadModel {
 }
 
 export default class DownloadModel {
-	isComplete = false
-	isDownloading = false
+	status: DownloadStatus = DownloadStatus.Pending
 	isNew = true
 
 	apiKey: string
@@ -54,6 +55,10 @@ export default class DownloadModel {
 		this.apiKey = apiKey;
 		this.filename = filename;
 		this.downloadUrl = downloadUrl;
+	}
+
+	get isComplete() {
+		return this.status === DownloadStatus.Complete;
 	}
 
 	/** @deprecated Use item.Id instead. */
@@ -126,7 +131,7 @@ export function fromStorageObject({
 		filename,
 		downloadUrl
 	);
-	model.isComplete = isComplete;
+	if (isComplete) model.status = DownloadStatus.Complete;
 	model.isNew = isNew;
 	return model;
 }

--- a/models/__tests__/DownloadModel.test.js
+++ b/models/__tests__/DownloadModel.test.js
@@ -71,6 +71,7 @@ describe('DownloadModel', () => {
 		expect(download.title).toBe(value.title);
 		expect(download.filename).toBe(value.filename);
 		expect(download.downloadUrl).toBe(value.downloadUrl);
+		expect(download.status).toBe(DownloadStatus.Complete);
 		expect(download.isComplete).toBe(value.isComplete);
 		expect(download.isNew).toBe(value.isNew);
 	});

--- a/models/__tests__/DownloadModel.test.js
+++ b/models/__tests__/DownloadModel.test.js
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { DownloadStatus } from '../../constants/DownloadStatus';
 import DownloadModel, { fromStorageObject } from '../DownloadModel';
 
 const DOCUMENT_DIRECTORY = '/DOC_DIR/';
@@ -38,7 +39,7 @@ describe('DownloadModel', () => {
 		expect(download.downloadUrl).toBe('https://example.com/download');
 
 		expect(download.isComplete).toBe(false);
-		expect(download.isDownloading).toBe(false);
+		expect(download.status).toBe(DownloadStatus.Pending);
 		expect(download.isNew).toBe(true);
 
 		expect(download.key).toBe('server-id_item-id');

--- a/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
@@ -107,11 +107,6 @@ exports[`DownloadScreen should render correctly 1`] = `
         style={null}
       >
         <View
-          accessibilityState={
-            Object {
-              "disabled": true,
-            }
-          }
           testID="list-item"
         >
           <View
@@ -266,11 +261,6 @@ exports[`DownloadScreen should render correctly 1`] = `
         style={null}
       >
         <View
-          accessibilityState={
-            Object {
-              "disabled": true,
-            }
-          }
           testID="list-item"
         >
           <View

--- a/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
@@ -27,8 +27,6 @@ exports[`DownloadScreen should render correctly 1`] = `
           "apiKey": "api-key",
           "downloadUrl": "https://example.com/download",
           "filename": "file name.mkv",
-          "isComplete": false,
-          "isDownloading": false,
           "isNew": true,
           "item": Object {
             "Id": "item-id",
@@ -37,13 +35,12 @@ exports[`DownloadScreen should render correctly 1`] = `
           },
           "serverUrl": "https://example.com/",
           "sessionId": "uuid-0",
+          "status": "pending",
         },
         DownloadModel {
           "apiKey": "api-key",
           "downloadUrl": "https://test2.example.com/download",
           "filename": "other file name.mkv",
-          "isComplete": false,
-          "isDownloading": false,
           "isNew": true,
           "item": Object {
             "Id": "item-id-2",
@@ -52,6 +49,7 @@ exports[`DownloadScreen should render correctly 1`] = `
           },
           "serverUrl": "https://test2.example.com/",
           "sessionId": "uuid-1",
+          "status": "pending",
         },
       ]
     }
@@ -61,8 +59,6 @@ exports[`DownloadScreen should render correctly 1`] = `
           "apiKey": "api-key",
           "downloadUrl": "https://example.com/download",
           "filename": "file name.mkv",
-          "isComplete": false,
-          "isDownloading": false,
           "isNew": true,
           "item": Object {
             "Id": "item-id",
@@ -71,13 +67,12 @@ exports[`DownloadScreen should render correctly 1`] = `
           },
           "serverUrl": "https://example.com/",
           "sessionId": "uuid-0",
+          "status": "pending",
         },
         "server-id_item-id-2" => DownloadModel {
           "apiKey": "api-key",
           "downloadUrl": "https://test2.example.com/download",
           "filename": "other file name.mkv",
-          "isComplete": false,
-          "isDownloading": false,
           "isNew": true,
           "item": Object {
             "Id": "item-id-2",
@@ -86,6 +81,7 @@ exports[`DownloadScreen should render correctly 1`] = `
           },
           "serverUrl": "https://test2.example.com/",
           "sessionId": "uuid-1",
+          "status": "pending",
         },
       }
     }

--- a/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
@@ -237,9 +237,27 @@ exports[`DownloadScreen should render correctly 1`] = `
                 }
               }
             />
-            <ActivityIndicator
-              testID="loading-indicator"
-            />
+            <View
+              style={
+                Object {
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View>
+                <View
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "transparent",
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <Text />
+                </View>
+              </View>
+            </View>
           </View>
         </View>
       </View>
@@ -377,9 +395,27 @@ exports[`DownloadScreen should render correctly 1`] = `
                 }
               }
             />
-            <ActivityIndicator
-              testID="loading-indicator"
-            />
+            <View
+              style={
+                Object {
+                  "overflow": "hidden",
+                }
+              }
+            >
+              <View>
+                <View
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "transparent",
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <Text />
+                </View>
+              </View>
+            </View>
           </View>
         </View>
       </View>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear download status indicator on list items: shows a spinner while downloading, a warning icon on failure, and a menu with Play/Delete when complete.
  * Tapping a list item now consistently plays the download (or selects it in edit mode).

* **Improvements**
  * Streamlined download state management to a single status, improving clarity and UI consistency.
  * Selection checkboxes are disabled until downloads are complete.

* **Bug Fixes**
  * Failed downloads now display an explicit warning and hide inappropriate actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->