### PR TITLE
Update download file structure

### DIFF
--- a/App.js
+++ b/App.js
@@ -197,8 +197,10 @@ const App = ({ skipLoadingScreen }) => {
 		const downloadFile = async (download) => {
 			console.debug('[App] downloading "%s"', download.filename);
 			// For transcoded downloads we force .mp4
-			download.extension = '.mp4';
-			downloadStore.update(download);
+			if (!download.extension) {
+				download.extension = '.mp4';
+				downloadStore.update(download);
+			}
 			await ensurePathExists(download.localPath);
 
 			const url = download.getStreamUrl(rootStore.deviceId);

--- a/App.js
+++ b/App.js
@@ -196,6 +196,9 @@ const App = ({ skipLoadingScreen }) => {
 	useEffect(() => {
 		const downloadFile = async (download) => {
 			console.debug('[App] downloading "%s"', download.filename);
+			// For transcoded downloads we force .mp4
+			download.extension = '.mp4';
+			downloadStore.update(download);
 			await ensurePathExists(download.localPath);
 
 			const url = download.getStreamUrl(rootStore.deviceId);

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -11,6 +11,7 @@ import * as FileSystem from 'expo-file-system';
 import { v4 as uuidv4 } from 'uuid';
 
 import { DownloadStatus } from '../constants/DownloadStatus';
+import { getItemDirectory, getItemFileName } from '../utils/baseItem';
 
 export interface DownloadItem extends BaseItemDto {
 	Id: string;
@@ -29,6 +30,8 @@ interface MobxDownloadModel {
 	isNew: boolean;
 }
 
+const DOWNLOADS_DIRECTORY = 'Downloads/';
+
 export default class DownloadModel {
 	status: DownloadStatus = DownloadStatus.Pending
 	isNew = true
@@ -39,7 +42,13 @@ export default class DownloadModel {
 	sessionId = uuidv4()
 	serverUrl: string
 
+	/** @deprecated Use item.Path and extension instead. */
 	filename: string
+	/**
+	 * Extension override for transcoded files. e.g. `.mkv`
+	 * By default the original file extension from `item.Path` is used.
+	 */
+	extension?: string
 
 	downloadUrl: string
 
@@ -61,6 +70,14 @@ export default class DownloadModel {
 		return this.status === DownloadStatus.Complete;
 	}
 
+	/**
+	 * Returns true if the download's localPath could be shared with other downloads.
+	 * e.g. Multiple episodes or songs could exist in the same directory.
+	 */
+	get isSharedPath() {
+		return !!(this.item.SeriesName || this.item.Album);
+	}
+
 	/** @deprecated Use item.Id instead. */
 	get itemId() {
 		return this.item.Id;
@@ -71,10 +88,21 @@ export default class DownloadModel {
 	}
 
 	get localFilename() {
+		const ext = this.extension ? this.extension : this.item.Path?.slice(this.item.Path.lastIndexOf('.'));
+		const name = getItemFileName(this.item);
+		if (name && ext) return `${name}${ext}`;
+
+		// Fallback for legacy downloads
 		return this.filename.slice(0, this.filename.lastIndexOf('.')) + '.mp4';
 	}
 
 	get localPath() {
+		const itemDirectory = getItemDirectory(this.item);
+		if (itemDirectory) {
+			return `${FileSystem.documentDirectory}${DOWNLOADS_DIRECTORY}${itemDirectory}`;
+		}
+
+		// Fallback for legacy downloads
 		return `${FileSystem.documentDirectory}${this.item.ServerId}/${this.item.Id}/`;
 	}
 
@@ -88,7 +116,7 @@ export default class DownloadModel {
 	}
 
 	get uri() {
-		return this.localPath + encodeURI(this.localFilename);
+		return encodeURI(this.localPath + this.localFilename);
 	}
 
 	getStreamUrl(deviceId: string, params?: Record<string, string>): URL {

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -88,7 +88,18 @@ export default class DownloadModel {
 	}
 
 	get localFilename() {
-		const ext = this.extension ? this.extension : this.item.Path?.slice(this.item.Path.lastIndexOf('.'));
+		let ext = this.extension;
+		// If no extension override is set, try to get the original from the item.Path
+		if (!ext) {
+			const path = this.item.Path;
+			if (path && path.lastIndexOf('.') > 0) {
+				ext = path.slice(path.lastIndexOf('.'));
+			}
+		}
+		// Ensure the extension starts with a "."
+		if (ext && ext[0] !== '.') {
+			ext = `.${ext}`;
+		}
 		const name = getItemFileName(this.item);
 		if (name && ext) return `${name}${ext}`;
 
@@ -104,6 +115,10 @@ export default class DownloadModel {
 
 		// Fallback for legacy downloads
 		return `${FileSystem.documentDirectory}${this.item.ServerId}/${this.item.Id}/`;
+	}
+
+	get localPathUri() {
+		return encodeURI(this.localPath);
 	}
 
 	/** @deprecated Use item.ServerId instead. */

--- a/models/__tests__/DownloadModel.test.js
+++ b/models/__tests__/DownloadModel.test.js
@@ -19,13 +19,16 @@ describe('DownloadModel', () => {
 			{
 				Id: 'item-id',
 				ServerId: 'server-id',
-				Name: 'title'
+				Name: 'title',
+				Path: 'title.mkv',
+				ProductionYear: 2025
 			},
 			'https://example.com/',
 			'api-key',
 			'file name.mkv',
 			'https://example.com/download'
 		);
+		download.extension = '.mp4';
 
 		expect(download.apiKey).toBe('api-key');
 		expect(download.itemId).toBe('item-id');
@@ -43,10 +46,55 @@ describe('DownloadModel', () => {
 		expect(download.isNew).toBe(true);
 
 		expect(download.key).toBe('server-id_item-id');
-		expect(download.localFilename).toBe('file name.mp4');
-		expect(download.localPath).toBe(`${DOCUMENT_DIRECTORY}server-id/item-id/`);
-		expect(download.uri).toBe(`${DOCUMENT_DIRECTORY}server-id/item-id/file%20name.mp4`);
+		expect(download.isSharedPath).toBe(false);
+		expect(download.localFilename).toBe('title (2025).mp4');
+		expect(download.localPath).toBe(`${DOCUMENT_DIRECTORY}Downloads/title (2025)/`);
+		expect(download.uri).toBe(`${DOCUMENT_DIRECTORY}Downloads/title%20(2025)/title%20(2025).mp4`);
 		expect(download.getStreamUrl('device-id').toString()).toBe('https://example.com/Videos/item-id/stream.mp4?deviceId=device-id&api_key=api-key&playSessionId=uuid-0&videoCodec=hevc%2Ch264&audioCodec=aac%2Cmp3%2Cac3%2Ceac3%2Cflac%2Calac&maxAudioChannels=6');
+	});
+
+	it('should return true if the download\'s localPath could be shared by other downloads', () => {
+		let download = new DownloadModel(
+			{
+				Id: 'item-id',
+				ServerId: 'server-id',
+				Album: 'Album Name'
+			},
+			'https://example.com/',
+			'api-key',
+			'file name.mkv',
+			'https://example.com/download'
+		);
+		expect(download.isSharedPath).toBe(true);
+
+		download = new DownloadModel(
+			{
+				Id: 'item-id',
+				ServerId: 'server-id',
+				SeriesName: 'Series Name'
+			},
+			'https://example.com/',
+			'api-key',
+			'file name.mkv',
+			'https://example.com/download'
+		);
+		expect(download.isSharedPath).toBe(true);
+	});
+
+	it('should return fallback values for legacy downloads', () => {
+		const download = new DownloadModel(
+			{
+				Id: 'item-id',
+				ServerId: 'server-id'
+			},
+			'https://example.com/',
+			'api-key',
+			'file name.mkv',
+			'https://example.com/download'
+		);
+
+		expect(download.title).toBeUndefined();
+		expect(download.localPath).toBe(`${DOCUMENT_DIRECTORY}server-id/item-id/`);
 	});
 
 	it('should create a DownloadModel from a storage object', () => {

--- a/models/__tests__/DownloadModel.test.js
+++ b/models/__tests__/DownloadModel.test.js
@@ -28,7 +28,7 @@ describe('DownloadModel', () => {
 			'file name.mkv',
 			'https://example.com/download'
 		);
-		download.extension = '.mp4';
+		download.extension = 'mp4';
 
 		expect(download.apiKey).toBe('api-key');
 		expect(download.itemId).toBe('item-id');
@@ -49,6 +49,7 @@ describe('DownloadModel', () => {
 		expect(download.isSharedPath).toBe(false);
 		expect(download.localFilename).toBe('title (2025).mp4');
 		expect(download.localPath).toBe(`${DOCUMENT_DIRECTORY}Downloads/title (2025)/`);
+		expect(download.localPathUri).toBe(`${DOCUMENT_DIRECTORY}Downloads/title%20(2025)/`);
 		expect(download.uri).toBe(`${DOCUMENT_DIRECTORY}Downloads/title%20(2025)/title%20(2025).mp4`);
 		expect(download.getStreamUrl('device-id').toString()).toBe('https://example.com/Videos/item-id/stream.mp4?deviceId=device-id&api_key=api-key&playSessionId=uuid-0&videoCodec=hevc%2Ch264&audioCodec=aac%2Cmp3%2Cac3%2Ceac3%2Cflac%2Calac&maxAudioChannels=6');
 	});
@@ -79,6 +80,23 @@ describe('DownloadModel', () => {
 			'https://example.com/download'
 		);
 		expect(download.isSharedPath).toBe(true);
+	});
+
+	it('should get the extension from item.Path if not set', () => {
+		const download = new DownloadModel(
+			{
+				Id: 'item-id',
+				ServerId: 'server-id',
+				Name: 'title',
+				Path: 'file name.mkv'
+			},
+			'https://example.com/',
+			'api-key',
+			'file name.mkv',
+			'https://example.com/download'
+		);
+
+		expect(download.localFilename).toBe('title.mkv');
 	});
 
 	it('should return fallback values for legacy downloads', () => {

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -37,7 +37,11 @@ const DownloadScreen = () => {
 	const deleteItem = useCallback(async (download: DownloadModel) => {
 		// TODO: Add user messaging on errors
 		try {
-			await FileSystem.deleteAsync(download.localPath);
+			// If the download is in a (potentially) shared directory, only delete the file
+			if (download.isSharedPath) await FileSystem.deleteAsync(download.uri);
+			// Otherwise delete the entire directory
+			else await FileSystem.deleteAsync(encodeURI(download.localPath));
+			// Delete the store value
 			downloadStore.delete(download);
 			console.log('[DownloadScreen] download "%s" deleted', download.title);
 		} catch (e) {

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -38,9 +38,9 @@ const DownloadScreen = () => {
 		// TODO: Add user messaging on errors
 		try {
 			// If the download is in a (potentially) shared directory, only delete the file
-			if (download.isSharedPath) await FileSystem.deleteAsync(download.uri);
+			if (download.isSharedPath) await FileSystem.deleteAsync(download.uri, { idempotent: true });
 			// Otherwise delete the entire directory
-			else await FileSystem.deleteAsync(encodeURI(download.localPath));
+			else await FileSystem.deleteAsync(download.localPathUri, { idempotent: true });
 			// Delete the store value
 			downloadStore.delete(download);
 			console.log('[DownloadScreen] download "%s" deleted', download.title);

--- a/utils/File.ts
+++ b/utils/File.ts
@@ -1,10 +1,15 @@
 /**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 import * as FileSystem from 'expo-file-system';
+
+const INVALID_DIR_CHARS = /[\\/:*?"<>|.]/g;
+const INVALID_FILE_CHARS = /[\\/:*?"<>|]/g;
 
 /**
  * Checks if a path exists, and creates a directory (including missing intermediate directories) if it does not.
@@ -15,4 +20,20 @@ export async function ensurePathExists(path: string) {
 	if (!info.exists) {
 		await FileSystem.makeDirectoryAsync(path, { intermediates: true });
 	}
+}
+
+/** Trim and replace any invalid characters in a directory name. */
+export function sanitizeDirName(name?: string) {
+	const trimmed = name?.trim();
+	if (!trimmed) return;
+
+	return trimmed.replace(INVALID_DIR_CHARS, '-');
+}
+
+/** Trim and replace any invalid characters in a file name. */
+export function sanitizeFileName(name?: string) {
+	const trimmed = name?.trim();
+	if (!trimmed) return;
+
+	return trimmed.replace(INVALID_FILE_CHARS, '-');
 }

--- a/utils/File.ts
+++ b/utils/File.ts
@@ -11,6 +11,11 @@ import * as FileSystem from 'expo-file-system';
 const INVALID_DIR_CHARS = /[\\/:*?"<>|.]/g;
 const INVALID_FILE_CHARS = /[\\/:*?"<>|]/g;
 
+const reduceReplacements = (s: string) => (
+	s.replace(/-+/g, '-') // collapse runs
+		.replace(/^-+|-+$/g, '') // trim leading/trailing
+);
+
 /**
  * Checks if a path exists, and creates a directory (including missing intermediate directories) if it does not.
  * @param path A uri of a local directory
@@ -27,7 +32,7 @@ export function sanitizeDirName(name?: string) {
 	const trimmed = name?.trim();
 	if (!trimmed) return;
 
-	return trimmed.replace(INVALID_DIR_CHARS, '-');
+	return reduceReplacements(trimmed.replace(INVALID_DIR_CHARS, '-'));
 }
 
 /** Trim and replace any invalid characters in a file name. */
@@ -35,5 +40,5 @@ export function sanitizeFileName(name?: string) {
 	const trimmed = name?.trim();
 	if (!trimmed) return;
 
-	return trimmed.replace(INVALID_FILE_CHARS, '-');
+	return reduceReplacements(trimmed.replace(INVALID_FILE_CHARS, '-'));
 }

--- a/utils/File.ts
+++ b/utils/File.ts
@@ -8,8 +8,7 @@
 
 import * as FileSystem from 'expo-file-system';
 
-const INVALID_DIR_CHARS = /[\\/:*?"<>|.]/g;
-const INVALID_FILE_CHARS = /[\\/:*?"<>|]/g;
+const INVALID_PATH_CHARS = /[\\/:*?"<>|.]/g;
 
 const reduceReplacements = (s: string) => (
 	s.replace(/-+/g, '-') // collapse runs
@@ -27,18 +26,14 @@ export async function ensurePathExists(path: string) {
 	}
 }
 
-/** Trim and replace any invalid characters in a directory name. */
-export function sanitizeDirName(name?: string) {
-	const trimmed = name?.trim();
-	if (!trimmed) return;
-
-	return reduceReplacements(trimmed.replace(INVALID_DIR_CHARS, '-'));
-}
-
-/** Trim and replace any invalid characters in a file name. */
+/** Trim and replace any invalid characters in a file/directory name (extension excluded). */
 export function sanitizeFileName(name?: string) {
 	const trimmed = name?.trim();
 	if (!trimmed) return;
 
-	return reduceReplacements(trimmed.replace(INVALID_FILE_CHARS, '-'));
+	const sanitized = reduceReplacements(
+		trimmed
+			.normalize('NFC')
+			.replace(INVALID_PATH_CHARS, '-'));
+	return sanitized || undefined;
 }

--- a/utils/__tests__/File.test.js
+++ b/utils/__tests__/File.test.js
@@ -6,7 +6,7 @@
 
 import { getInfoAsync, makeDirectoryAsync } from 'expo-file-system';
 
-import { ensurePathExists } from '../File';
+import { ensurePathExists, sanitizeDirName, sanitizeFileName } from '../File';
 
 jest.mock('expo-file-system');
 
@@ -34,6 +34,26 @@ describe('File', () => {
 
 			expect(getInfoAsync).toHaveBeenCalled();
 			expect(makeDirectoryAsync).toHaveBeenCalled();
+		});
+	});
+
+	describe('sanitizeDirName', () => {
+		it('should sanitize directory names', () => {
+			let name = sanitizeDirName(' Q: A.? ');
+			expect(name).toBe('Q- A--');
+
+			name = sanitizeDirName('AC/DC');
+			expect(name).toBe('AC-DC');
+		});
+	});
+
+	describe('sanitizeFileName', () => {
+		it('should sanitize file names', () => {
+			let name = sanitizeFileName(' Q: A?.mp3 ');
+			expect(name).toBe('Q- A-.mp3');
+
+			name = sanitizeFileName('AC/DC');
+			expect(name).toBe('AC-DC');
 		});
 	});
 });

--- a/utils/__tests__/File.test.js
+++ b/utils/__tests__/File.test.js
@@ -6,7 +6,7 @@
 
 import { getInfoAsync, makeDirectoryAsync } from 'expo-file-system';
 
-import { ensurePathExists, sanitizeDirName, sanitizeFileName } from '../File';
+import { ensurePathExists, sanitizeFileName } from '../File';
 
 jest.mock('expo-file-system');
 
@@ -37,20 +37,10 @@ describe('File', () => {
 		});
 	});
 
-	describe('sanitizeDirName', () => {
-		it('should sanitize directory names', () => {
-			let name = sanitizeDirName(' Q: A.? ');
-			expect(name).toBe('Q- A');
-
-			name = sanitizeDirName('AC/DC');
-			expect(name).toBe('AC-DC');
-		});
-	});
-
 	describe('sanitizeFileName', () => {
-		it('should sanitize file names', () => {
-			let name = sanitizeFileName(' *<>Q: A?.mp3 ');
-			expect(name).toBe('Q- A-.mp3');
+		it('should sanitize directory names', () => {
+			let name = sanitizeFileName(' Q: A.? ');
+			expect(name).toBe('Q- A');
 
 			name = sanitizeFileName('AC/DC');
 			expect(name).toBe('AC-DC');

--- a/utils/__tests__/File.test.js
+++ b/utils/__tests__/File.test.js
@@ -40,7 +40,7 @@ describe('File', () => {
 	describe('sanitizeDirName', () => {
 		it('should sanitize directory names', () => {
 			let name = sanitizeDirName(' Q: A.? ');
-			expect(name).toBe('Q- A--');
+			expect(name).toBe('Q- A');
 
 			name = sanitizeDirName('AC/DC');
 			expect(name).toBe('AC-DC');
@@ -49,7 +49,7 @@ describe('File', () => {
 
 	describe('sanitizeFileName', () => {
 		it('should sanitize file names', () => {
-			let name = sanitizeFileName(' Q: A?.mp3 ');
+			let name = sanitizeFileName(' *<>Q: A?.mp3 ');
 			expect(name).toBe('Q- A-.mp3');
 
 			name = sanitizeFileName('AC/DC');

--- a/utils/__tests__/File.test.js
+++ b/utils/__tests__/File.test.js
@@ -38,12 +38,25 @@ describe('File', () => {
 	});
 
 	describe('sanitizeFileName', () => {
-		it('should sanitize directory names', () => {
+		it('should sanitize file names', () => {
 			let name = sanitizeFileName(' Q: A.? ');
 			expect(name).toBe('Q- A');
 
 			name = sanitizeFileName('AC/DC');
 			expect(name).toBe('AC-DC');
+		});
+
+		it('should collapse multiple invalid characters and trim safely', () => {
+			expect(sanitizeFileName('A:::B???///')).toBe('A-B');
+			expect(sanitizeFileName('---???.')).toBeUndefined();
+			expect(sanitizeFileName('   ')).toBeUndefined();
+		});
+
+		it('should normalize Unicode to NFC', () => {
+			// "e" + combining accent (NFD) should normalize equivalently
+			const nfd = 'Cafe\u0301'; // Café
+			const nfc = 'Café';
+			expect(sanitizeFileName(nfd)).toBe(nfc);
 		});
 	});
 });

--- a/utils/__tests__/baseItem.test.js
+++ b/utils/__tests__/baseItem.test.js
@@ -62,6 +62,10 @@ describe('getItemDirectory', () => {
 
 		item.AlbumArtist = 'Ozzy Osbourne';
 		expect(getItemDirectory(item)).toBe('Ozzy Osbourne/Album Name/');
+
+		item.Album = '  ** ';
+		item.AlbumArtist = ':?\\';
+		expect(getItemDirectory(item)).toBe('Unknown Artist/Unknown Album/');
 	});
 
 	it('should handle episodes correctly', () => {
@@ -71,6 +75,11 @@ describe('getItemDirectory', () => {
 			ProductionYear: 2025
 		};
 		expect(getItemDirectory(item)).toBe('Series Name (2025)/Season 3/');
+
+		item.SeriesName = '   ';
+		delete item.ParentIndexNumber;
+		delete item.ProductionYear;
+		expect(getItemDirectory(item)).toBeUndefined();
 	});
 
 	it('should fallback to name and year when possible', () => {
@@ -130,6 +139,8 @@ describe('getItemFileName', () => {
 	});
 
 	it('should return undefined when no name or year is present', () => {
+		expect(getItemFileName({ Name: '   ' })).toBeUndefined();
+
 		expect(getItemFileName({})).toBeUndefined();
 	});
 });

--- a/utils/__tests__/baseItem.test.js
+++ b/utils/__tests__/baseItem.test.js
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { getItemSubtitle } from '../baseItem';
+import { getItemDirectory, getItemFileName, getItemSubtitle } from '../baseItem';
 
 describe('getItemSubtitle', () => {
 	it('should handle episodes correctly', () => {
@@ -50,5 +50,86 @@ describe('getItemSubtitle', () => {
 
 	it('should return undefined when production year is unavailable', () => {
 		expect(getItemSubtitle({})).toBeUndefined();
+	});
+});
+
+describe('getItemDirectory', () => {
+	it('should handle songs correctly', () => {
+		const item = {
+			Album: 'Album Name'
+		};
+		expect(getItemDirectory(item)).toBe('Unknown Artist/Album Name/');
+
+		item.AlbumArtist = 'Ozzy Osbourne';
+		expect(getItemDirectory(item)).toBe('Ozzy Osbourne/Album Name/');
+	});
+
+	it('should handle episodes correctly', () => {
+		const item = {
+			SeriesName: 'Series Name',
+			ParentIndexNumber: 3,
+			ProductionYear: 2025
+		};
+		expect(getItemDirectory(item)).toBe('Series Name (2025)/Season 3/');
+	});
+
+	it('should fallback to name and year when possible', () => {
+		const item = {
+			Name: 'Item Name'
+		};
+		expect(getItemDirectory(item)).toBe('Item Name/');
+
+		item.ProductionYear = 2025;
+		expect(getItemDirectory(item)).toBe('Item Name (2025)/');
+	});
+
+	it('should return undefined when no name or year is present', () => {
+		expect(getItemDirectory({})).toBeUndefined();
+	});
+});
+
+describe('getItemFileName', () => {
+	it('should handle songs correctly', () => {
+		const item = {
+			Album: 'Album Name'
+		};
+		expect(getItemFileName(item)).toBeUndefined();
+
+		item.Name = 'Song Name';
+		expect(getItemFileName(item)).toBe('Song Name');
+
+		item.IndexNumber = 2;
+		expect(getItemFileName(item)).toBe('2 - Song Name');
+
+		delete item.Name;
+		expect(getItemFileName(item)).toBe('2');
+	});
+
+	it('should handle episodes correctly', () => {
+		const item = {
+			SeriesName: 'Series Name'
+		};
+		expect(getItemFileName(item)).toBe('Series Name');
+
+		item.ParentIndexNumber = 3;
+		item.IndexNumber = 15;
+		expect(getItemFileName(item)).toBe('Series Name - S3E15');
+
+		item.Name = 'Episode Name';
+		expect(getItemFileName(item)).toBe('Series Name - S3E15 - Episode Name');
+	});
+
+	it('should fallback to name and year when possible', () => {
+		const item = {
+			Name: 'Item Name'
+		};
+		expect(getItemFileName(item)).toBe('Item Name');
+
+		item.ProductionYear = 2025;
+		expect(getItemFileName(item)).toBe('Item Name (2025)');
+	});
+
+	it('should return undefined when no name or year is present', () => {
+		expect(getItemFileName({})).toBeUndefined();
 	});
 });

--- a/utils/baseItem.ts
+++ b/utils/baseItem.ts
@@ -8,7 +8,7 @@
 
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
 
-import { sanitizeDirName, sanitizeFileName } from './File';
+import { sanitizeFileName } from './File';
 
 /** Gets the short episode ID for display. e.g. S2E5-6 */
 const getShortEpisodeId = (item: BaseItemDto): string | undefined => {
@@ -67,10 +67,10 @@ export const getItemDirectory = (item: BaseItemDto): string | undefined => {
 	// from the BaseItem of the song.
 	if (item.Album) {
 		const artist = item.AlbumArtist ? item.AlbumArtist : 'Unknown Artist';
-		return `${sanitizeDirName(artist)}/${sanitizeDirName(item.Album)}/`;
+		return `${sanitizeFileName(artist)}/${sanitizeFileName(item.Album)}/`;
 	}
 
-	const nameAndYear = sanitizeDirName(getNameAndYear(item));
+	const nameAndYear = sanitizeFileName(getNameAndYear(item));
 
 	// Episodes will use: Series Name (2025)/Season 1/
 	if (item.SeriesName && typeof item.ParentIndexNumber !== 'undefined') {

--- a/utils/baseItem.ts
+++ b/utils/baseItem.ts
@@ -8,19 +8,37 @@
 
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
 
+/** Gets the short episode ID for display. e.g. S2E5-6 */
+const getShortEpisodeId = (item: BaseItemDto): string | undefined => {
+	let episode = '';
+	if (typeof item.ParentIndexNumber !== 'undefined') {
+		episode += `S${item.ParentIndexNumber}`;
+	}
+	if (typeof item.IndexNumber !== 'undefined') {
+		episode += `E${item.IndexNumber}`;
+		if (typeof item.IndexNumberEnd !== 'undefined') {
+			episode += `-${item.IndexNumberEnd}`;
+		}
+	}
+	return episode || undefined;
+};
+
+/** Gets the name and year of an item for display. e.g. Name (2025) */
+const getNameAndYear = (item: BaseItemDto): string | undefined => {
+	const name = item.SeriesName ? item.SeriesName : item.Name;
+	if (name) {
+		if (item.ProductionYear) return `${name} (${item.ProductionYear})`;
+		return name;
+	}
+};
+
+/**
+ * Gets the subtitle that should be displayed under an item's name.
+ */
 export const getItemSubtitle = (item: BaseItemDto): string | undefined => {
 	// Episodes will show: Series Name S1E5-6
 	if (item.SeriesName) {
-		let episode = '';
-		if (typeof item.ParentIndexNumber !== 'undefined') {
-			episode += `S${item.ParentIndexNumber}`;
-		}
-		if (typeof item.IndexNumber !== 'undefined') {
-			episode += `E${item.IndexNumber}`;
-			if (typeof item.IndexNumberEnd !== 'undefined') {
-				episode += `-${item.IndexNumberEnd}`;
-			}
-		}
+		const episode = getShortEpisodeId(item);
 		return episode ? `${item.SeriesName} ${episode}` : item.SeriesName;
 	}
 
@@ -36,4 +54,57 @@ export const getItemSubtitle = (item: BaseItemDto): string | undefined => {
 
 	// Everything else will show the production year or fallback to the filename for legacy downloads
 	return item.ProductionYear?.toString();
+};
+
+/**
+ * Gets the directory path that an item should be saved under.
+ */
+export const getItemDirectory = (item: BaseItemDto): string | undefined => {
+	// Songs will use: Artist Name/Album Name/
+	// NOTE: It would be better to separate by Disc but we have no way of identifying songs from multi-disc albums
+	// from the BaseItem of the song.
+	if (item.Album) {
+		const artist = item.AlbumArtist ? item.AlbumArtist : 'Unknown Artist';
+		return `${artist}/${item.Album}/`;
+	}
+
+	const nameAndYear = getNameAndYear(item);
+
+	// Episodes will use: Series Name (2025)/Season 1/
+	if (item.SeriesName && typeof item.ParentIndexNumber !== 'undefined') {
+		return `${nameAndYear}/Season ${item.ParentIndexNumber}/`;
+	}
+
+	// Everything else should use: Item Name (2025)/
+	if (nameAndYear) {
+		return `${nameAndYear}/`;
+	}
+};
+
+export const getItemFileName = (item: BaseItemDto): string | undefined => {
+	// Songs will use: 5 - Song Name
+	// NOTE: It would be better to include the Disc number but we have no way of identifying songs from multi-disc
+	// albums from the BaseItem of the song.
+	if (item.Album) {
+		return [
+			item.IndexNumber,
+			item.Name
+		]
+			.filter(t => !!t)
+			.join(' - ') || undefined;
+	}
+
+	// Episodes will use: Series Name - S01E5-6 - Episode Name
+	if (item.SeriesName) {
+		return [
+			item.SeriesName,
+			getShortEpisodeId(item),
+			item.Name
+		]
+			.filter(t => !!t)
+			.join(' - ');
+	}
+
+	// Everything else should use: Item Name (2025)
+	return getNameAndYear(item);
 };

--- a/utils/baseItem.ts
+++ b/utils/baseItem.ts
@@ -54,7 +54,7 @@ export const getItemSubtitle = (item: BaseItemDto): string | undefined => {
 			.join(' · ');
 	}
 
-	// Everything else will show the production year or fallback to the filename for legacy downloads
+	// Everything else will show the production year if available
 	return item.ProductionYear?.toString();
 };
 
@@ -66,19 +66,20 @@ export const getItemDirectory = (item: BaseItemDto): string | undefined => {
 	// NOTE: It would be better to separate by Disc but we have no way of identifying songs from multi-disc albums
 	// from the BaseItem of the song.
 	if (item.Album) {
-		const artist = item.AlbumArtist ? item.AlbumArtist : 'Unknown Artist';
-		return `${sanitizeFileName(artist)}/${sanitizeFileName(item.Album)}/`;
+		const artist = sanitizeFileName(item.AlbumArtist || undefined) || 'Unknown Artist';
+		const album = sanitizeFileName(item.Album) || 'Unknown Album';
+		return `${artist}/${album}/`;
 	}
 
 	const nameAndYear = sanitizeFileName(getNameAndYear(item));
 
-	// Episodes will use: Series Name (2025)/Season 1/
-	if (item.SeriesName && typeof item.ParentIndexNumber !== 'undefined') {
-		return `${nameAndYear}/Season ${item.ParentIndexNumber}/`;
-	}
-
-	// Everything else should use: Item Name (2025)/
 	if (nameAndYear) {
+		// Episodes will use: Series Name (2025)/Season 1/
+		if (item.SeriesName && typeof item.ParentIndexNumber !== 'undefined') {
+			return `${nameAndYear}/Season ${item.ParentIndexNumber}/`;
+		}
+
+		// Everything else should use: Item Name (2025)/
 		return `${nameAndYear}/`;
 	}
 };


### PR DESCRIPTION
Update download file structure to be based on the item name and other metadata instead of using server ID and item ID. Maintains fallbacks for the previous structure for existing downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter download naming and organization: per-item folders and clearer filenames (titles with optional year, episode/season formatting, Artist/Album for songs).
  * Per-download extension override supported; missing extensions now default to .mp4.
  * Filenames and folders are sanitized and normalized; encoded local path/URI exposed for sharing/streaming.
* **Bug Fixes**
  * Safer deletion: when folders may be shared, only the specific file is removed; otherwise the directory is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->