### PR TITLE
Allow downloading any media type

### DIFF
--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import React, { useCallback, useMemo, type FC } from 'react';
 import { ListItem } from 'react-native-elements';
 
@@ -33,14 +34,17 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	isEditMode = false,
 	isSelected = false
 }) => {
+	// NOTE: Currently only video has a native UI to play within the app.
+	// The media type check should be removed when we have a native audio player UI available.
+	const canPlay = useMemo(() => item.canPlay && item.item.MediaType === MediaType.Video, [ item.canPlay, item.item.MediaType ]);
 	const subtitle = useMemo(() => item.item && getItemSubtitle(item.item), [ item.item ]);
 
 	const onItemPress = useCallback(() => {
 		// Call select callback if in edit mode
 		if (isEditMode) onSelect();
 		// Otherwise call play callback
-		else onPlay();
-	}, [ isEditMode, onPlay, onSelect ]);
+		else if (canPlay) onPlay();
+	}, [ canPlay, isEditMode, onPlay, onSelect ]);
 
 	return (
 		<ListItem
@@ -78,6 +82,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 
 			<DownloadStatusIndicator
 				download={item}
+				canPlay={canPlay}
 				isEditMode={isEditMode}
 				onDelete={onDelete}
 				onPlay={onPlay}

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -36,15 +36,17 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 }) => {
 	// NOTE: Currently only video has a native UI to play within the app.
 	// The media type check should be removed when we have a native audio player UI available.
-	const canPlay = useMemo(() => item.canPlay && item.item.MediaType === MediaType.Video, [ item.canPlay, item.item.MediaType ]);
+	const canPlayInApp = useMemo(() => (
+		item.canPlay && item.item.MediaType === MediaType.Video
+	), [ item.canPlay, item.item.MediaType ]);
 	const subtitle = useMemo(() => item.item && getItemSubtitle(item.item), [ item.item ]);
 
 	const onItemPress = useCallback(() => {
 		// Call select callback if in edit mode
 		if (isEditMode) onSelect();
 		// Otherwise call play callback
-		else if (canPlay) onPlay();
-	}, [ canPlay, isEditMode, onPlay, onSelect ]);
+		else if (canPlayInApp) onPlay();
+	}, [ canPlayInApp, isEditMode, onPlay, onSelect ]);
 
 	return (
 		<ListItem
@@ -82,7 +84,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 
 			<DownloadStatusIndicator
 				download={item}
-				canPlay={canPlay}
+				canPlayInApp={canPlayInApp}
 				isEditMode={isEditMode}
 				onDelete={onDelete}
 				onPlay={onPlay}

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -39,7 +39,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	const canPlayInApp = useMemo(() => (
 		item.canPlay && item.item.MediaType === MediaType.Video
 	), [ item.canPlay, item.item.MediaType ]);
-	const subtitle = useMemo(() => item.item && getItemSubtitle(item.item), [ item.item ]);
+	const subtitle = useMemo(() => getItemSubtitle(item.item), [ item.item ]);
 
 	const onItemPress = useCallback(() => {
 		// Call select callback if in edit mode
@@ -53,7 +53,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			testID='list-item'
 			topDivider={index === 0}
 			bottomDivider
-			onPress={item.isComplete ? onItemPress : undefined}
+			onPress={item.isComplete && (isEditMode || canPlayInApp) ? onItemPress : undefined}
 		>
 			{isEditMode &&
 				<ListItem.CheckBox

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -6,10 +6,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import type { MenuAction } from '@react-native-menu/menu';
 import React, { useCallback, useContext, useMemo, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator } from 'react-native';
-
 import { ListItem, ThemeContext } from 'react-native-elements';
 
 import { DownloadStatus } from '../constants/DownloadStatus';
@@ -22,18 +22,20 @@ import { MenuPressEvent } from './MenuViewButton/types';
 
 interface DownloadStatusIndicatorProps {
 	download: DownloadModel;
+	canPlay: boolean;
 	isEditMode?: boolean;
 	onDelete: () => void;
 	onPlay: () => void;
 }
 
-const MenuAction = {
+const DownloadAction = {
 	Delete: 'delete',
 	PlayInApp: 'play_in_app'
 } as const;
 
 const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	download,
+	canPlay,
 	isEditMode = false,
 	onDelete,
 	onPlay
@@ -42,27 +44,35 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	const { theme } = useContext(ThemeContext);
 	const { t } = useTranslation();
 
-	const menuActions = useMemo(() => [
-		{
-			id: MenuAction.PlayInApp,
-			title: t('common.play'),
-			image: 'play'
-		},
-		{
-			id: MenuAction.Delete,
-			title: t('common.delete'),
-			attributes: {
-				destructive: true
-			},
-			image: 'trash'
+	const menuActions = useMemo<MenuAction[]>(() => {
+		const actions: MenuAction[] = [];
+
+		if (canPlay) {
+			actions.push({
+				id: DownloadAction.PlayInApp,
+				title: t('common.play'),
+				image: 'play'
+			});
 		}
-	], [ t ]);
+
+		return [
+			...actions,
+			{
+				id: DownloadAction.Delete,
+				title: t('common.delete'),
+				attributes: {
+					destructive: true
+				},
+				image: 'trash'
+			}
+		];
+	}, [ canPlay, t ]);
 
 	const onMenuPress = useCallback(({ nativeEvent }: MenuPressEvent) => {
 		switch (nativeEvent.event) {
-			case MenuAction.PlayInApp:
+			case DownloadAction.PlayInApp:
 				return onPlay();
-			case MenuAction.Delete:
+			case DownloadAction.Delete:
 				return onDelete();
 			default:
 				console.warn('[DownloadStatusIndicator.onMenuPress] unhandled menu press action', nativeEvent.event);

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -22,7 +22,7 @@ import { MenuPressEvent } from './MenuViewButton/types';
 
 interface DownloadStatusIndicatorProps {
 	download: DownloadModel;
-	canPlay: boolean;
+	canPlayInApp: boolean;
 	isEditMode?: boolean;
 	onDelete: () => void;
 	onPlay: () => void;
@@ -35,7 +35,7 @@ const DownloadAction = {
 
 const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	download,
-	canPlay,
+	canPlayInApp,
 	isEditMode = false,
 	onDelete,
 	onPlay
@@ -47,7 +47,7 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	const menuActions = useMemo<MenuAction[]>(() => {
 		const actions: MenuAction[] = [];
 
-		if (canPlay) {
+		if (canPlayInApp) {
 			actions.push({
 				id: DownloadAction.PlayInApp,
 				title: t('common.play'),
@@ -66,7 +66,7 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 				image: 'trash'
 			}
 		];
-	}, [ canPlay, t ]);
+	}, [ canPlayInApp, t ]);
 
 	const onMenuPress = useCallback(({ nativeEvent }: MenuPressEvent) => {
 		switch (nativeEvent.event) {

--- a/components/MenuViewButton/index.ios.tsx
+++ b/components/MenuViewButton/index.ios.tsx
@@ -62,11 +62,15 @@ const MenuViewButton: FC<MenuViewButtonProps> = ({
 			type='ionicon'
 			color={theme.colors?.black}
 			disabled={disabled}
+			// eslint-disable-next-line react-native/no-color-literals
+			disabledStyle={{
+				backgroundColor: 'transparent'
+			}}
 			onPress={onPress}
 		/>
 	);
 
-	if (isMenuSupported) {
+	if (isMenuSupported && !disabled) {
 		return (
 			<MenuView {...menuProps}>
 				{button}

--- a/components/MenuViewButton/index.tsx
+++ b/components/MenuViewButton/index.tsx
@@ -21,17 +21,29 @@ const MenuViewButton: FC<MenuViewButtonProps> = ({
 }) => {
 	const { theme } = useContext(ThemeContext);
 
-	return (
-		<MenuView {...menuProps}>
-			<ListItem.Chevron
-				name='ellipsis-horizontal'
-				type='ionicon'
-				color={theme.colors?.black}
-				disabled={disabled}
-				onPress={() => { /* no-op */ }}
-			/>
-		</MenuView>
+	const button = (
+		<ListItem.Chevron
+			name='ellipsis-horizontal'
+			type='ionicon'
+			color={theme.colors?.black}
+			disabled={disabled}
+			// eslint-disable-next-line react-native/no-color-literals
+			disabledStyle={{
+				backgroundColor: 'transparent'
+			}}
+			onPress={() => { /* no-op */ }}
+		/>
 	);
+
+	if (!disabled) {
+		return (
+			<MenuView {...menuProps}>
+				{button}
+			</MenuView>
+		);
+	}
+
+	return button;
 };
 
 MenuViewButton.displayName = 'MenuViewButton';

--- a/components/NativeShellWebView.tsx
+++ b/components/NativeShellWebView.tsx
@@ -102,13 +102,6 @@ true;
 					break;
 				case 'downloadFile': {
 					console.log('Download item', data);
-					if (data.item.item?.MediaType !== MediaType.Video) {
-						Alert.alert(
-							t('alerts.downloadUnsupported.title'),
-							t('alerts.downloadUnsupported.description')
-						);
-						break;
-					}
 
 					// Get the API key from the download URL
 					let apiKey;

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
@@ -21,7 +22,8 @@ describe('DownloadListItem', () => {
 			{
 				Id: 'item-id',
 				ServerId: 'server-id',
-				Name: 'title'
+				Name: 'title',
+				MediaType: MediaType.Video
 			},
 			'https://example.com/',
 			'api-key',
@@ -59,6 +61,7 @@ describe('DownloadListItem', () => {
 		const onPlay = jest.fn();
 		const onDelete = jest.fn();
 
+		model.canPlay = true;
 		model.status = DownloadStatus.Complete;
 
 		const { getByTestId, queryByTestId } = render(

--- a/hooks/useDownloadHandler.ts
+++ b/hooks/useDownloadHandler.ts
@@ -86,6 +86,7 @@ export const useDownloadHandler = (enabled = false) => {
 					// For direct play we must build the URL ourselves
 					console.debug('[useDownloadHandler] media source will direct play/stream', firstMediaSource);
 					const endpoint = download.item.MediaType === MediaType.Video ? 'Videos' : 'Audio';
+					download.canPlay = true;
 					download.extension = `.${firstMediaSource.Container || ''}`;
 
 					const streamParams = new URLSearchParams({
@@ -107,6 +108,7 @@ export const useDownloadHandler = (enabled = false) => {
 					isTranscoding = true;
 					url = new URL(firstMediaSource.TranscodingUrl, serverUrl);
 
+					download.canPlay = true;
 					download.extension = `.${firstMediaSource.TranscodingContainer || ''}`;
 				} else {
 					// If we can't direct play or transcode, then we will fallback to using the default download URL

--- a/langs/en.json
+++ b/langs/en.json
@@ -95,10 +95,6 @@
         "title": "Download Failed",
         "description": "\"{{title}}\" failed to download."
     },
-    "downloadUnsupported": {
-        "title": "Unsupported Type",
-        "description": "Downloading content of this type is not currently supported."
-    },
     "resetApplication": {
       "title": "Reset Application",
       "description": "Are you sure you want to reset all settings?",

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -35,6 +35,7 @@ const DOWNLOADS_DIRECTORY = 'Downloads/';
 export default class DownloadModel {
 	status: DownloadStatus = DownloadStatus.Pending
 	isNew = true
+	canPlay = false
 
 	apiKey: string
 	readonly item: Readonly<DownloadItem>
@@ -160,5 +161,7 @@ export function fromStorageObject({
 	);
 	if (isComplete) model.status = DownloadStatus.Complete;
 	model.isNew = isNew;
+	// Any downloads from the mobx store should be playable
+	model.canPlay = true;
 	return model;
 }

--- a/models/__tests__/DownloadModel.test.js
+++ b/models/__tests__/DownloadModel.test.js
@@ -44,6 +44,7 @@ describe('DownloadModel', () => {
 		expect(download.isComplete).toBe(false);
 		expect(download.status).toBe(DownloadStatus.Pending);
 		expect(download.isNew).toBe(true);
+		expect(download.canPlay).toBe(false);
 
 		expect(download.key).toBe('server-id_item-id');
 		expect(download.isSharedPath).toBe(false);
@@ -139,5 +140,6 @@ describe('DownloadModel', () => {
 		expect(download.status).toBe(DownloadStatus.Complete);
 		expect(download.isComplete).toBe(value.isComplete);
 		expect(download.isNew).toBe(value.isNew);
+		expect(download.canPlay).toBe(true);
 	});
 });

--- a/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
@@ -22,6 +22,7 @@ exports[`DownloadScreen should render correctly 1`] = `
       Array [
         DownloadModel {
           "apiKey": "api-key",
+          "canPlay": false,
           "downloadUrl": "https://example.com/download",
           "filename": "file name.mkv",
           "isNew": true,
@@ -36,6 +37,7 @@ exports[`DownloadScreen should render correctly 1`] = `
         },
         DownloadModel {
           "apiKey": "api-key",
+          "canPlay": false,
           "downloadUrl": "https://test2.example.com/download",
           "filename": "other file name.mkv",
           "isNew": true,
@@ -54,6 +56,7 @@ exports[`DownloadScreen should render correctly 1`] = `
       Map {
         "server-id_item-id" => DownloadModel {
           "apiKey": "api-key",
+          "canPlay": false,
           "downloadUrl": "https://example.com/download",
           "filename": "file name.mkv",
           "isNew": true,
@@ -68,6 +71,7 @@ exports[`DownloadScreen should render correctly 1`] = `
         },
         "server-id_item-id-2" => DownloadModel {
           "apiKey": "api-key",
+          "canPlay": false,
           "downloadUrl": "https://test2.example.com/download",
           "filename": "other file name.mkv",
           "isNew": true,

--- a/stores/DownloadStore.ts
+++ b/stores/DownloadStore.ts
@@ -42,6 +42,7 @@ interface SerializedDownload {
 	/** @deprecated Use status instead. */
 	isComplete?: boolean;
 	isNew: boolean;
+	canPlay?: boolean;
 	status?: DownloadStatus;
 }
 
@@ -93,6 +94,8 @@ export const deserialize = (valueString: string | null): StorageValue<State> => 
 				model.status = DownloadStatus.Complete;
 			}
 			model.isNew = obj.isNew;
+			// Any pre-existing download without canPlay defined should be playable
+			if (typeof obj.canPlay === 'undefined') model.canPlay = true;
 
 			downloads.set(key, model);
 		});

--- a/stores/DownloadStore.ts
+++ b/stores/DownloadStore.ts
@@ -95,7 +95,7 @@ export const deserialize = (valueString: string | null): StorageValue<State> => 
 			}
 			model.isNew = obj.isNew;
 			// Any pre-existing download without canPlay defined should be playable
-			if (typeof obj.canPlay === 'undefined') model.canPlay = true;
+			model.canPlay = typeof obj.canPlay === 'boolean' ? obj.canPlay : true;
 
 			downloads.set(key, model);
 		});


### PR DESCRIPTION
Allows downloading items with any media type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Play option now appears only for items that can be played in-app.
  - Previously stored downloads are treated as playable by default when applicable.
- Bug Fixes
  - Prevents accidental play attempts on non-playable items.
  - Removes the “Unsupported Type” alert and allows non-video downloads to proceed.
- Tests
  - Updated tests to cover playability rules, menu actions, and related UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->