### PR TITLE
Add concurrent download limit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,7 +89,7 @@
         "no-unused-expressions": ["error", { "allowShortCircuit": true, "allowTernary": true, "allowTaggedTemplates": true }],
         "no-unused-vars": ["error"],
         "no-var": ["error"],
-        "no-void": ["error"],
+        "no-void": ["error", { "allowAsStatement": true }],
         "object-curly-spacing": ["error", "always"],
         "one-var": ["error", "never"],
         "padded-blocks": ["error", "never"],

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -111,6 +111,14 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 					color={theme.colors?.error}
 				/>
 			);
+		case DownloadStatus.Pending:
+			return (
+				<ListItem.Chevron
+					type='ionicon'
+					name='cloud-download-outline'
+					color={theme.colors?.black}
+				/>
+			);
 		default:
 			return (
 				<ListItem.Chevron


### PR DESCRIPTION
* Limits downloads to 3 concurrent downloads to prevent overloading servers
* Updates the pending download icon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a dedicated “Pending” icon for downloads awaiting start, improving status clarity.
- Refactor
  - Introduced bounded concurrency for downloads (up to three at a time) with dynamic scheduling for smoother, more controlled processing.
- Chores
  - Updated ESLint configuration to allow void expressions as standalone statements while maintaining existing rule enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->