### PR TITLE
Fix download extension persistence

### DIFF
--- a/stores/DownloadStore.ts
+++ b/stores/DownloadStore.ts
@@ -38,6 +38,7 @@ interface SerializedDownload {
 	apiKey: string;
 	title?: string;
 	filename: string;
+	extension?: string;
 	downloadUrl: string;
 	/** @deprecated Use status instead. */
 	isComplete?: boolean;
@@ -93,9 +94,10 @@ export const deserialize = (valueString: string | null): StorageValue<State> => 
 				// Migrate legacy completed status.
 				model.status = DownloadStatus.Complete;
 			}
-			model.isNew = obj.isNew;
 			// Any pre-existing download without canPlay defined should be playable
 			model.canPlay = typeof obj.canPlay === 'boolean' ? obj.canPlay : true;
+			model.extension = obj.extension;
+			model.isNew = obj.isNew;
 
 			downloads.set(key, model);
 		});

--- a/stores/__tests__/DownloadStore.test.js
+++ b/stores/__tests__/DownloadStore.test.js
@@ -132,6 +132,7 @@ describe('deserialize', () => {
 						apiKey: 'api-key',
 						title: 'title 2',
 						filename: 'file name 2.mkv',
+						extension: '.mp4',
 						downloadUrl: 'https://example.com/download',
 						isComplete: true,
 						isNew: false
@@ -164,6 +165,7 @@ describe('deserialize', () => {
 		expect(model2.apiKey).toBe('api-key');
 		expect(model2.title).toBe('title 2');
 		expect(model2.filename).toBe('file name 2.mkv');
+		expect(model2.extension).toBe('.mp4');
 		expect(model2.downloadUrl).toBe('https://example.com/download');
 		expect(model2.isComplete).toBe(true);
 		expect(model2.isNew).toBe(false);


### PR DESCRIPTION
* Fixes the download extension not being persisted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads now retain and restore file extension information for better file-type recognition and more accurate sorting/filtering.
  * File details and icons reflect the correct type, improving identification and app association.
  * Playback behavior remains unchanged.

* **Tests**
  * Added coverage to verify extension is preserved during restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->