### PR TITLE
Fix legacy download file paths

### DIFF
--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -114,9 +114,12 @@ export default class DownloadModel {
 	}
 
 	get localPath() {
-		const itemDirectory = getItemDirectory(this.item);
-		if (itemDirectory) {
-			return `${FileSystem.documentDirectory}${DOWNLOADS_DIRECTORY}${itemDirectory}`;
+		// Legacy downloads will not have a path set
+		if (this.item.Path) {
+			const itemDirectory = getItemDirectory(this.item);
+			if (itemDirectory) {
+				return `${FileSystem.documentDirectory}${DOWNLOADS_DIRECTORY}${itemDirectory}`;
+			}
 		}
 
 		// Fallback for legacy downloads


### PR DESCRIPTION
Fixes file path generation for legacy downloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older downloads by safely resolving file locations when newer path data is missing.
  * Reduced errors and edge cases when item metadata is incomplete, ensuring downloads remain accessible.
  * Maintains existing behavior for items with modern path data; no changes to how current downloads are stored or found.

* **Chores**
  * Added clarifying comments related to legacy download handling (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->