### PR TITLE
Add sharing download items

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,7 @@
     "expo-linking",
     "expo-localization",
     "expo-screen-orientation",
+    "expo-sharing",
     "expo-splash-screen",
     "expo-status-bar",
     "expo-system-ui",

--- a/features/downloads/constants/DownloadAction.ts
+++ b/features/downloads/constants/DownloadAction.ts
@@ -13,7 +13,9 @@ export const DownloadAction = {
 	/** Open the download in the Files app. */
 	OpenInFiles: 'open_in_files',
 	/** Play the download within this app. */
-	PlayInApp: 'play_in_app'
+	PlayInApp: 'play_in_app',
+	/** Share the download via the iOS action sheet. */
+	Share: 'share'
 } as const;
 
 export type DownloadAction = typeof DownloadAction[keyof typeof DownloadAction];

--- a/features/downloads/utils/downloadItemActions.ts
+++ b/features/downloads/utils/downloadItemActions.ts
@@ -12,31 +12,42 @@ import type DownloadModel from '../../../models/DownloadModel';
 import { DownloadAction } from '../constants/DownloadAction';
 import type { DownloadItemAction } from '../types/downloadItemAction';
 
-export const getDownloadItemActions = (download: DownloadModel): DownloadItemAction[] => [
-	{
-		id: DownloadAction.PlayInApp,
-		title: 'common.play',
-		image: 'play',
-		isDefault: true,
-		isEnabled: true,
-		// NOTE: Currently only video has a native UI to play within the app.
-		// The media type check should be removed when we have a native audio player UI available.
-		isSupported: download.canPlay && download.item.MediaType === MediaType.Video
-	},
-	{
-		id: DownloadAction.OpenInFiles,
-		title: 'common.openInFiles',
-		image: 'folder',
-		isDefault: true,
-		isEnabled: true,
-		isSupported: true
-	},
-	{
-		id: DownloadAction.Delete,
-		title: 'common.delete',
-		image: 'trash',
-		isDestructive: true,
-		isEnabled: true,
-		isSupported: true
-	}
-];
+export const getDownloadItemActions = (download: DownloadModel): DownloadItemAction[] => {
+	// NOTE: Currently only video has a native UI to play within the app.
+	// The media type check should be removed when we have a native audio player UI available.
+	const isPlayableInApp = download.canPlay && download.item.MediaType === MediaType.Video;
+
+	return [
+		{
+			id: DownloadAction.PlayInApp,
+			title: 'common.play',
+			image: 'play',
+			isDefault: true,
+			isEnabled: true,
+			isSupported: isPlayableInApp
+		},
+		{
+			id: DownloadAction.OpenInFiles,
+			title: 'common.openInFiles',
+			image: 'folder',
+			isDefault: true,
+			isEnabled: true,
+			isSupported: true
+		},
+		{
+			id: DownloadAction.Share,
+			title: 'common.share',
+			image: 'square.and.arrow.up',
+			isEnabled: true,
+			isSupported: true
+		},
+		{
+			id: DownloadAction.Delete,
+			title: 'common.delete',
+			image: 'trash',
+			isDestructive: true,
+			isEnabled: true,
+			isSupported: true
+		}
+	];
+};

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -33,6 +33,8 @@ PODS:
   - EXScreenOrientation (4.3.0):
     - ExpoModulesCore
     - React-Core
+  - EXSharing (10.3.0):
+    - ExpoModulesCore
   - EXSplashScreen (0.16.2):
     - ExpoModulesCore
     - React-Core
@@ -419,6 +421,7 @@ DEPENDENCIES:
   - ExpoSystemUI (from `../node_modules/expo-system-ui/ios`)
   - ExpoWebBrowser (from `../node_modules/expo-web-browser/ios`)
   - EXScreenOrientation (from `../node_modules/expo-screen-orientation/ios`)
+  - EXSharing (from `../node_modules/expo-sharing/ios`)
   - EXSplashScreen (from `../node_modules/expo-splash-screen/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
@@ -498,6 +501,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-web-browser/ios"
   EXScreenOrientation:
     :path: "../node_modules/expo-screen-orientation/ios"
+  EXSharing:
+    :path: "../node_modules/expo-sharing/ios"
   EXSplashScreen:
     :path: "../node_modules/expo-splash-screen/ios"
   FBLazyVector:
@@ -596,6 +601,7 @@ SPEC CHECKSUMS:
   ExpoSystemUI: 98b3c736973da9abaeb87d2e20adeb4b306a0aa7
   ExpoWebBrowser: 5b018c2aea1934bfc82914915fbe9f0cdc35127b
   EXScreenOrientation: 608ec6bfbecc14c7ba6dd7a263a53fd6fd134cca
+  EXSharing: 02486e351adba9227d0ee3bb3ccd1dc453d29b2b
   EXSplashScreen: be364303b208e8579aecaab39a854c0976b46cb7
   FBLazyVector: d3c1d2923b1009f4e709e8f1b793dedf5b323454
   FBReactNativeSpec: d460df7d796ed4979c6cd4e092145b63eb28b5bb

--- a/langs/en.json
+++ b/langs/en.json
@@ -7,6 +7,7 @@
     "ok": "OK",
     "openInFiles": "Open in Files",
     "play": "Play",
+    "share": "Share",
     "unknown": "Unknown"
   },
   "headings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7357,6 +7357,12 @@
         "@expo/config-plugins": "~5.0.0"
       }
     },
+    "expo-sharing": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-10.3.0.tgz",
+      "integrity": "sha512-j3kn43WCOykj7mlGTb5Q3Z56DG8raFdTk0A+rauA7lsmJ5Vakb2qGyTFZ7uwqwrML10EQIPAzNEcEYgpIzHKIw==",
+      "requires": {}
+    },
     "expo-splash-screen": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.16.2.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "expo-linking": "~3.2.4",
     "expo-localization": "~13.1.0",
     "expo-screen-orientation": "~4.3.0",
+    "expo-sharing": "~10.3.0",
     "expo-splash-screen": "~0.16.2",
     "expo-status-bar": "~1.4.0",
     "expo-system-ui": "~1.3.0",

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -10,6 +10,7 @@ import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type'
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import * as FileSystem from 'expo-file-system';
 import * as Linking from 'expo-linking';
+import * as Sharing from 'expo-sharing';
 import React, { useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert, FlatList, StyleSheet, View } from 'react-native';
@@ -92,10 +93,21 @@ const DownloadScreen = () => {
 					uri: item.uri
 				});
 				return;
+			case DownloadAction.Share: {
+				console.debug('[DownloadScreen] sharing download uri', item.uri);
+				Sharing.shareAsync(item.uri)
+					.catch(err => {
+						console.warn('[DownloadScreen] failed to share', err);
+					});
+				return;
+			}
 			case DownloadAction.OpenInFiles: {
 				const uri = getFilesUri(item.uri);
-				console.debug('[DownloadScreen] opening uri', uri);
-				Linking.openURL(uri);
+				console.debug('[DownloadScreen] opening Files uri', uri);
+				Linking.openURL(uri)
+					.catch(err => {
+						console.warn('[DownloadScreen] failed to open Files', err);
+					});
 			}
 		}
 	}, [ downloadStore, mediaStore, onDeleteItems ]);


### PR DESCRIPTION
* Adds sharing support to the download menu allowing for playback in other apps (like VLC)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Share” action to downloads, enabling system share sheet for a file’s URI.
  - Added English label for “Share.”
- Bug Fixes
  - Improved stability and error handling when opening files and sharing (safer URL open, warnings on failure).
- Chores
  - Added expo-sharing dependency.
  - Updated Renovate config to ignore expo-sharing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->