### PR TITLE
Bump build version to 1.7.0.5

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "1.7.0.4",
+      "buildNumber": "1.7.0.5",
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -30,7 +30,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.7.0.4</string>
+    <string>1.7.0.5</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>LSSupportsOpeningDocumentsInPlace</key>


### PR DESCRIPTION
Bumps the build version to 1.7.0.5 for TestFlight release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build number to 1.7.0.5 to prepare the next App Store/TestFlight build.
  * No feature changes or bug fixes included in this update.
  * Users may notice the new build number in app settings or TestFlight, but functionality remains unchanged.
  * This is a maintenance release to align versioning for distribution and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->