### PR TITLE
Fix transcode downloads progress and add subtitle support

### DIFF
--- a/features/downloads/hooks/useDownloadHandler.ts
+++ b/features/downloads/hooks/useDownloadHandler.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { EncodingContext } from '@jellyfin/sdk/lib/generated-client/models';
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { getMediaInfoApi } from '@jellyfin/sdk/lib/utils/api/media-info-api';
 import { getPlaystateApi } from '@jellyfin/sdk/lib/utils/api/playstate-api';
@@ -57,14 +56,11 @@ export const useDownloadHandler = (enabled = false) => {
 				download.item.MediaType &&
 				STREAMING_MEDIA_TYPES.includes(download.item.MediaType)
 			) {
-				// Filter any HLS transcoding profiles out for downloads
-				const DeviceProfile = toDownloadProfile(getDeviceProfile());
-
 				const { data: playbackInfo } = await getMediaInfoApi(api)
 					.getPostedPlaybackInfo({
 						itemId: download.item.Id,
 						playbackInfoDto: {
-							DeviceProfile
+							DeviceProfile: toDownloadProfile(getDeviceProfile())
 						}
 					});
 

--- a/features/downloads/utils/profile.ts
+++ b/features/downloads/utils/profile.ts
@@ -19,6 +19,7 @@ export const toDownloadProfile = (playbackProfile: DeviceProfile): DeviceProfile
 	const downloadProfile = {
 		...playbackProfile,
 		Name: playbackProfile.Name?.replace(' Native Profile', ' Download Profile'),
+		// Filter any HLS transcoding profiles out for downloads
 		TranscodingProfiles: (playbackProfile.TranscodingProfiles || [])
 			.filter(p => p.Protocol !== MediaStreamProtocol.Hls),
 		SubtitleProfiles

--- a/features/downloads/utils/profile.ts
+++ b/features/downloads/utils/profile.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { SubtitleDeliveryMethod, type SubtitleProfile } from '@jellyfin/sdk/lib/generated-client/models';
+import type { DeviceProfile } from '@jellyfin/sdk/lib/generated-client/models/device-profile';
+import { MediaStreamProtocol } from '@jellyfin/sdk/lib/generated-client/models/media-stream-protocol';
+
+const SubtitleProfiles: SubtitleProfile[] = [
+	{ Method: SubtitleDeliveryMethod.Encode }
+];
+
+/** Converts a playback DeviceProfile to one used for downloads. */
+export const toDownloadProfile = (playbackProfile: DeviceProfile): DeviceProfile => {
+	const downloadProfile = {
+		...playbackProfile,
+		Name: playbackProfile.Name?.replace(' Native Profile', ' Download Profile'),
+		TranscodingProfiles: (playbackProfile.TranscodingProfiles || [])
+			.filter(p => p.Protocol !== MediaStreamProtocol.Hls),
+		SubtitleProfiles
+	};
+	return downloadProfile;
+};


### PR DESCRIPTION
* Fixes transcoded downloads marking content as played
* Adds subtitle support for transcoded download profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of offline downloads by using a download-optimized device profile to avoid streaming-only formats.
  * Downloaded videos now include encoded subtitles when available for better compatibility.
  * Resume and progress tracking for downloads is more accurate; stop positions are captured even during transcoding.
  * More stable playback info requests during download setup, reducing edge-case errors across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->