### PR TITLE
Add script for bumping version numbers

### DIFF
--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# bump_version - increase the app version and push to a new branch
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+usage() {
+    echo -e "bump_version - increase the app version"
+    echo -e ""
+    echo -e "Usage:"
+    echo -e " $ bump_version <new_version>"
+}
+
+if [[ -z $1 ]]; then
+    usage
+    exit 1
+fi
+
+build_version="$1"
+version="${build_version%.*}"
+
+# Create a new git branch
+git fetch upstream
+git checkout -b bump-${build_version} --no-track upstream/master
+
+# Update the version numbers in app.json
+jq --arg bv "${build_version}" --arg v "${version}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
+
+# Run prebuild to update the version in ios/Jellyfin/Info.plist
+npx expo prebuild --platform ios
+
+# Commit and push the changes
+git add app.json ios/Jellyfin/Info.plist
+git commit -m "Bump build number to ${build_version}"
+git push -u origin bump-${build_version}


### PR DESCRIPTION
Adds a script to have a consistent way of bumping version numbers. The script accepts the build number (i.e. "1.7.0.6") as a parameter and extracts the three digit version number from it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automation to handle app version updates and release branch creation, including updating version metadata and iOS build information, running required prebuild steps, and committing/pushing changes.
  * Ensures consistent versioning across configurations with basic validation and error handling.
  * No user-facing changes; features and UI remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->