### PR TITLE
Update device profiles

### DIFF
--- a/components/NativeShellWebView.tsx
+++ b/components/NativeShellWebView.tsx
@@ -189,7 +189,7 @@ true;
 					console.warn('[Browser Console]', data);
 					break;
 				default:
-					console.debug('[HomeScreen.onMessage]', event, data);
+					console.debug('[HomeScreen.onMessage]', event, JSON.stringify(data));
 			}
 		} catch (ex) {
 			console.warn('Exception handling message', state.data);

--- a/utils/profiles/base.ts
+++ b/utils/profiles/base.ts
@@ -34,10 +34,16 @@ const BaseProfile = {
 					Value: 'high|main|baseline|constrained baseline'
 				},
 				{
+					Condition: ProfileConditionType.EqualsAny,
+					IsRequired: false,
+					Property: ProfileConditionValue.VideoRangeType,
+					Value: 'SDR'
+				},
+				{
 					Condition: ProfileConditionType.LessThanEqual,
 					IsRequired: false,
 					Property: ProfileConditionValue.VideoLevel,
-					Value: '51'
+					Value: '52'
 				},
 				{
 					Condition: ProfileConditionType.NotEquals,
@@ -64,16 +70,34 @@ const BaseProfile = {
 					Value: 'main|main 10'
 				},
 				{
+					Condition: ProfileConditionType.EqualsAny,
+					IsRequired: false,
+					Property: ProfileConditionValue.VideoRangeType,
+					Value: 'SDR|HDR10'
+				},
+				{
 					Condition: ProfileConditionType.LessThanEqual,
 					IsRequired: false,
 					Property: ProfileConditionValue.VideoLevel,
-					Value: '183'
+					Value: '153'
 				},
 				{
 					Condition: ProfileConditionType.NotEquals,
 					IsRequired: false,
 					Property: ProfileConditionValue.IsInterlaced,
 					Value: 'true'
+				},
+				{
+					Condition: ProfileConditionType.EqualsAny,
+					IsRequired: true,
+					Property: ProfileConditionValue.VideoCodecTag,
+					Value: 'hvc1'
+				},
+				{
+					Condition: ProfileConditionType.LessThanEqual,
+					IsRequired: true,
+					Property: ProfileConditionValue.VideoFramerate,
+					Value: '60'
 				}
 			],
 			Type: CodecType.Video

--- a/utils/profiles/ios-13.ts
+++ b/utils/profiles/ios-13.ts
@@ -143,6 +143,8 @@ const IosProfile = {
 			Type: DlnaProfileType.Video,
 			VideoCodec: 'h264'
 		},
+		// NOTE: hevc should also be a supported VideoCodec, but the server is failing to properly handle
+		// VideoCodecTag conditions for progressive transcodes.
 		// NOTE: Video transcoding profiles with a static context value seem ignored?
 		{
 			AudioCodec: 'aac,mp3,ac3,eac3,flac,alac',


### PR DESCRIPTION
Updates device profiles to fix issues with hevc playback in the native player. Also updates the h264 profile video level and specify SDR only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved video playback compatibility: refined profiles for SDR and HDR10, better HEVC support, and a 60 fps cap to enhance stability across devices.
  - Reduced issues with interlaced content through stricter handling in transcoding profiles.

- Chores
  - Enhanced diagnostic logging for incoming messages to aid troubleshooting.

- Documentation
  - Added clarifying notes around HEVC support and server behavior for transcoding profiles on iOS 13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->