### PR TITLE
Fix repeated presses on missing items

### DIFF
--- a/features/downloads/components/DownloadListItem.tsx
+++ b/features/downloads/components/DownloadListItem.tsx
@@ -12,7 +12,6 @@ import { ListItem } from 'react-native-elements';
 import type DownloadModel from '../../../models/DownloadModel';
 import { getItemSubtitle } from '../../../utils/baseItem';
 import type { DownloadAction } from '../constants/DownloadAction';
-import { DownloadStatus } from '../constants/DownloadStatus';
 import type { DownloadItemAction } from '../types/downloadItemAction';
 
 import DownloadStatusIndicator from './DownloadStatusIndicator';
@@ -53,11 +52,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			testID='list-item'
 			topDivider={index === 0}
 			bottomDivider
-			onPress={
-				((isEditMode && item.isComplete) || item.status === DownloadStatus.Complete)
-					? onItemPress
-					: undefined
-			}
+			onPress={item.isComplete ? onItemPress : undefined}
 		>
 			{isEditMode &&
 				<ListItem.CheckBox

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -74,6 +74,10 @@ export default class DownloadModel {
 		this.downloadUrl = downloadUrl;
 	}
 
+	/**
+	 * Returns true if a download has completed.
+	 * e.g. The status is not Pending or Downloading.
+	 */
 	get isComplete() {
 		return COMPLETE_STATUSES.includes(this.status);
 	}

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -107,16 +107,25 @@ const DownloadScreen = () => {
 	}, [ deleteItem, exitEditMode, t ]);
 
 	const onAction = useCallback(async (action: DownloadAction, item: DownloadModel) => {
+		// TODO: Allow retrying/removing failed downloads
+		if (item.status === DownloadStatus.Failed) return;
+
 		// Verify the download has not been removed from the file system
 		const info = await FileSystem.getInfoAsync(item.uri);
 		if (!info.exists) {
-			item.status = DownloadStatus.Missing;
-			downloadStore.update(item);
+			if (item.status !== DownloadStatus.Missing) {
+				item.status = DownloadStatus.Missing;
+				downloadStore.update(item);
+			}
 			Alert.alert(
 				t('alerts.missingDownload.title'),
 				t('alerts.missingDownload.description')
 			);
 			return;
+		} else if (item.status === DownloadStatus.Missing) {
+			// The download exists so update the status
+			item.status = DownloadStatus.Complete;
+			downloadStore.update(item);
 		}
 
 		switch (action) {


### PR DESCRIPTION
Fixes repeated presses on missing items not showing the alert

Fixes #734 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Tapping a download is only enabled once it’s fully complete, reducing accidental actions.
  - More accurate completion detection across the app ensures consistent behavior and status display.
- **Bug Fixes**
  - Prevents actions on failed downloads and shows a clear alert when a file is missing.
  - Correctly updates status from Missing to Complete when files reappear, avoiding redundant status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->