### PR TITLE
Bump build number to 1.7.0.7

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "1.7.0.6",
+      "buildNumber": "1.7.0.7",
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -30,7 +30,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.7.0.6</string>
+    <string>1.7.0.7</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>LSSupportsOpeningDocumentsInPlace</key>


### PR DESCRIPTION
Bumps the build number for the next TestFlight release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented iOS build number to 1.7.0.7 to prepare the next release.
  * Updated iOS app metadata only; no changes to features, settings, or permissions.
  * Users may see the new build number in TestFlight/App Store; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->