### PR TITLE
Bump build number to 1.7.0.8

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "1.7.0.7",
+      "buildNumber": "1.7.0.8",
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -30,7 +30,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.7.0.7</string>
+    <string>1.7.0.8</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>LSSupportsOpeningDocumentsInPlace</key>


### PR DESCRIPTION
Bumps the build number for the next TestFlight build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated iOS build number from 1.7.0.7 to 1.7.0.8 to align with release sequencing and distribution requirements.
  - Ensures accurate versioning in TestFlight/App Store and device settings.
  - No user-facing changes: features, performance, and stability remain unchanged.
  - Android and other platforms are unaffected by this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->