### PR TITLE
Mitigate pull_request_target privilege escalation

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
 
 jobs:
   labeling:


### PR DESCRIPTION
Hotfix: replace `pull_request_target` with `pull_request` to stop granting write permissions and secret access to fork PRs.

Some workflows will break (PR comments, labeling, deploy previews). Can be restored later with `workflow_run`.

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

See also: https://github.com/jellyfin/jellyfin-ios/pull/784