### PR TITLE
Fix using container directly as file extension

### DIFF
--- a/features/downloads/hooks/useDownloadHandler.ts
+++ b/features/downloads/hooks/useDownloadHandler.ts
@@ -20,6 +20,7 @@ import type DownloadModel from '../../../models/DownloadModel';
 import { getDeviceProfile } from '../../../utils/Device';
 import { ensurePathExists } from '../../../utils/File';
 import { DownloadStatus } from '../constants/DownloadStatus';
+import { getContainerExtension } from '../utils/file';
 import { toDownloadProfile } from '../utils/profile';
 
 interface DownloadMetadata {
@@ -61,7 +62,8 @@ const getDownloadMetadata = async (
 		console.debug('[useDownloadHandler] media source will direct play/stream', firstMediaSource);
 		const endpoint = download.item.MediaType === MediaType.Video ? 'Videos' : 'Audio';
 		download.canPlay = true;
-		download.extension = `.${firstMediaSource.Container || ''}`;
+		const streamExtension = `.${firstMediaSource.Container || ''}`;
+		download.extension = getContainerExtension(download.item, firstMediaSource.Container);
 
 		const streamParams = new URLSearchParams({
 			deviceId: api.deviceInfo.id,
@@ -75,7 +77,7 @@ const getDownloadMetadata = async (
 		return {
 			isTranscoding: false,
 			url: new URL(
-				`/${endpoint}/${download.item.Id}/stream${download.extension}?${streamParams.toString()}`,
+				`/${endpoint}/${download.item.Id}/stream${streamExtension}?${streamParams.toString()}`,
 				api.basePath
 			)
 		};
@@ -84,7 +86,7 @@ const getDownloadMetadata = async (
 		console.debug('[useDownloadHandler] media source will transcode', firstMediaSource);
 
 		download.canPlay = true;
-		download.extension = `.${firstMediaSource.TranscodingContainer || ''}`;
+		download.extension = getContainerExtension(download.item, firstMediaSource.TranscodingContainer);
 
 		return {
 			isTranscoding: true,

--- a/features/downloads/utils/file.ts
+++ b/features/downloads/utils/file.ts
@@ -1,0 +1,25 @@
+import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
+
+/** Returns the extension of a file path, including the dot. */
+export function getExtension(path: string | undefined | null) {
+	if (!path) return undefined;
+	return `.${path.split('.').pop()}`;
+}
+
+/** Returns the extension of a media container, including the dot. */
+export function getContainerExtension(item: BaseItemDto, container?: string | undefined | null) {
+	const containers = (container || item.Container || '')
+		.split(',')
+		.map(ext => `.${ext}`);
+
+	// If there's only one container, use it as the extension
+	if (containers.length === 1) return containers[0];
+
+	// If a container matches the original file extension, use it
+	const ext = getExtension(item.Path);
+	if (ext && containers.includes(ext)) return ext;
+
+	// Otherwise, use the first container
+	console.error(`No matching container found for ${item.Path} in ${containers.join(', ')}, using ${containers[0]}`);
+	return containers[0];
+}

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -12,6 +12,7 @@ import * as FileSystem from 'expo-file-system';
 import { v4 as uuidv4 } from 'uuid';
 
 import { DownloadStatus } from '../features/downloads/constants/DownloadStatus';
+import { getExtension } from '../features/downloads/utils/file';
 import { getItemDirectory, getItemFileName } from '../utils/baseItem';
 
 export interface DownloadItem extends BaseItemDto {
@@ -104,12 +105,7 @@ export default class DownloadModel {
 	get localFilename() {
 		let ext = this.extension;
 		// If no extension override is set, try to get the original from the item.Path
-		if (!ext) {
-			const path = this.item.Path;
-			if (path && path.lastIndexOf('.') > 0) {
-				ext = path.slice(path.lastIndexOf('.'));
-			}
-		}
+		if (!ext) ext = getExtension(this.item.Path);
 		// Ensure the extension starts with a "."
 		if (ext && ext[0] !== '.') {
 			ext = `.${ext}`;


### PR DESCRIPTION
### Changes
The container can be a coma delimited string. Using this directly as the file extension for a download causes iOS to not know what the file is. This updates the logic if there are multiple to try to match it against the extension used in the item's path or fallback to the first container in the list.

### Issues
None?

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
