### PR TITLE
Add a workflow for bumping the app version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -40,7 +40,8 @@ jobs:
             build_version="${{ inputs.build_version }}"
             version="${build_version%.*}"
             jq --arg bv "${build_version}" --arg v "${version}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
-            npx expo prebuild --platform ios
+            npm run build -- --no-install
+            git diff package.json
             npm version "${version}"
             git add app.json ios/Jellyfin/Info.plist package.json package-lock.json
             git checkout .

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -37,7 +37,8 @@ jobs:
             version="${${{ inputs.build_version }}%.*}"
             jq --arg bv "${{ inputs.build_version }}" --arg v "${version}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
             npx expo prebuild --platform ios
-            git add app.json ios/Jellyfin/Info.plist
+            npm version "${version}"
+            git add app.json ios/Jellyfin/Info.plist package.json package-lock.json
             git checkout .
           COMMIT_MESSAGE: "Bump build number to ${{ inputs.build_version }}"
           COMMIT_NAME: jellyfin-bot

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -34,8 +34,9 @@ jobs:
         uses: technote-space/create-pr-action@91114507cf92349bec0a9a501c2edf1635427bc5 # v2.1.4
         with:
           EXECUTE_COMMANDS: |
-            version="${${{ inputs.build_version }}%.*}"
-            jq --arg bv "${{ inputs.build_version }}" --arg v "${version}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
+            build_version="${{ inputs.build_version }}"
+            version="${build_version%.*}"
+            jq --arg bv "${build_version}" --arg v "${version}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
             npx expo prebuild --platform ios
             npm version "${version}"
             git add app.json ios/Jellyfin/Info.plist package.json package-lock.json

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -30,6 +30,9 @@ jobs:
           check-latest: true
           cache: npm
 
+      - name: Install Node.js dependencies
+        run: npm ci --no-audit
+
       - name: Bump the version and open a PR
         uses: technote-space/create-pr-action@91114507cf92349bec0a9a501c2edf1635427bc5 # v2.1.4
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,51 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_version:
+        description: New version
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  bump-version:
+    name: Bump Version
+    runs-on: macos-26
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          check-latest: true
+          cache: npm
+
+      - name: Bump the version and open a PR
+        uses: technote-space/create-pr-action@91114507cf92349bec0a9a501c2edf1635427bc5 # v2.1.4
+        with:
+          EXECUTE_COMMANDS: |
+            version="${${{ inputs.build_version }}%.*}"
+            jq --arg bv "${{ inputs.build_version }}" --arg v "${version}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
+            npx expo prebuild --platform ios
+            git add app.json ios/Jellyfin/Info.plist
+            git checkout .
+          COMMIT_MESSAGE: "Bump build number to ${{ inputs.build_version }}"
+          COMMIT_NAME: jellyfin-bot
+          COMMIT_EMAIL: team@jellyfin.org
+          PR_BRANCH_PREFIX: bump-
+          PR_BRANCH_NAME: ${{ inputs.build_version }}
+          PR_TITLE: "Bump build number to ${{ inputs.build_version }}"
+          PR_BODY: |
+            ### Changes
+            Bumps the build number to ${{ inputs.build_version }}
+          GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -33,16 +33,20 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci --no-audit
 
+      - name: Set version
+        run: |
+          build_version="${{ inputs.build_version }}"
+          version="${build_version%.*}"
+          echo "version=$version" >> $GITHUB_ENV
+
       - name: Bump the version and open a PR
         uses: technote-space/create-pr-action@91114507cf92349bec0a9a501c2edf1635427bc5 # v2.1.4
         with:
           EXECUTE_COMMANDS: |
-            build_version="${{ inputs.build_version }}"
-            version="${build_version%.*}"
-            jq --arg bv "${build_version}" --arg v "${version}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
+            echo "Bumping version to ${{ env.version }} (build ${{ inputs.build_version }})"
+            jq --arg bv "${{ inputs.build_version }}" --arg v "${{ env.version }}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
             npm run build -- --no-install
-            git diff package.json
-            npm version "${version}"
+            npm version "${{ env.version }}"
             git add app.json ios/Jellyfin/Info.plist package.json package-lock.json
             git checkout .
           COMMIT_MESSAGE: "Bump build number to ${{ inputs.build_version }}"

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -40,9 +40,7 @@ jobs:
           cache: npm
 
       - name: Install Node.js dependencies
-        run: |
-          npm ci --no-audit
-          git apply patches/boost1760.patch
+        run: npm ci --no-audit
 
       - name: Setup signing environment
         env:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jellyfin-ios",
   "version": "1.8.0",
   "scripts": {
+    "postinstall": "git apply patches/boost1760.patch",
     "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -29,7 +29,7 @@ git checkout -b bump-${build_version} --no-track upstream/master
 jq --arg bv "${build_version}" --arg v "${version}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
 
 # Run prebuild to update the version in ios/Jellyfin/Info.plist
-npx expo prebuild --platform ios
+npm run build -- --no-install
 
 # Update package.json version
 npm version "${version}"

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -31,7 +31,10 @@ jq --arg bv "${build_version}" --arg v "${version}" '.expo.version |= $v | .expo
 # Run prebuild to update the version in ios/Jellyfin/Info.plist
 npx expo prebuild --platform ios
 
+# Update package.json version
+npm version "${version}"
+
 # Commit and push the changes
-git add app.json ios/Jellyfin/Info.plist
+git add app.json ios/Jellyfin/Info.plist package.json package-lock.json
 git commit -m "Bump build number to ${build_version}"
 git push -u origin bump-${build_version}


### PR DESCRIPTION
### Changes
Adds a workflow for bumping the app version to avoid needing to run the `bump-version` script locally and opening a PR

### Issues
None

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
