### PR TITLE
Fix bump version failing if only the build changes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -46,7 +46,7 @@ jobs:
             echo "Bumping version to ${{ env.version }} (build ${{ inputs.build_version }})"
             jq --arg bv "${{ inputs.build_version }}" --arg v "${{ env.version }}" '.expo.version |= $v | .expo.ios.buildNumber |= $bv' app.json > app.tmp.json && mv app.tmp.json app.json
             npm run build -- --no-install
-            npm version "${{ env.version }}"
+            npm version --allow-same-version "${{ env.version }}"
             git add app.json ios/Jellyfin/Info.plist package.json package-lock.json
             git checkout .
           COMMIT_MESSAGE: "Bump build number to ${{ inputs.build_version }}"

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -32,7 +32,7 @@ jq --arg bv "${build_version}" --arg v "${version}" '.expo.version |= $v | .expo
 npm run build -- --no-install
 
 # Update package.json version
-npm version "${version}"
+npm version --allow-same-version "${version}"
 
 # Commit and push the changes
 git add app.json ios/Jellyfin/Info.plist package.json package-lock.json


### PR DESCRIPTION
### Changes
Fixes the bump version action/script failing on `npm version` when only the build number is changed

### Issues
None

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
