### PR TITLE
Rollback uuid version to fix broken metro build

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,6 +32,27 @@ jobs:
       - name: Run eslint
         run: npm run lint
 
+  metro:
+    name: Metro Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          check-latest: true
+          cache: npm
+
+      - name: Install Node.js dependencies
+        run: npm ci --no-audit
+
+      - name: Run Metro Build
+        run: npx expo export --platform ios
+
   typescript:
     name: TypeScript Build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage
+dist
 fastlane/report.xml
 node_modules/**/*
 .expo/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1457,13 +1457,6 @@
         "mv": "~2",
         "safe-json-stringify": "~1",
         "uuid": "^8.0.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
       }
     },
     "@expo/cli": {
@@ -2001,13 +1994,6 @@
         "node-fetch": "^2.6.1",
         "remove-trailing-slash": "^0.1.0",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
       }
     },
     "@expo/sdk-runtime-versions": {
@@ -11745,13 +11731,6 @@
             "lru-cache": "^6.0.0"
           }
         },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true,
-          "optional": true
-        },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -15245,9 +15224,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jellyfin-ios",
   "version": "1.8.0",
   "scripts": {
-    "postinstall": "git apply patches/boost1760.patch",
+    "postinstall": "git apply patches/boost1760.patch || true",
     "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
@@ -84,7 +84,7 @@
     "react-native-url-polyfill": "1.3.0",
     "react-native-web": "~0.18.7",
     "react-native-webview": "11.23.0",
-    "uuid": "11.1.1",
+    "uuid": "8.3.2",
     "zustand": "5.0.14"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes
- Rolls back the uuid package to fix the broken metro build
- Adds a CI job to perform the metro build on PRs

### Issues
None filed. Broken publish build [here](https://github.com/jellyfin/jellyfin-ios/actions/runs/31621162788).

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
