### PR TITLE
Add subtitle download support for offline videos

### DIFF
--- a/features/downloads/hooks/useDownloadHandler.ts
+++ b/features/downloads/hooks/useDownloadHandler.ts
@@ -22,6 +22,7 @@ import { ensurePathExists } from '../../../utils/File';
 import { DownloadStatus } from '../constants/DownloadStatus';
 import { getContainerExtension } from '../utils/file';
 import { toDownloadProfile } from '../utils/profile';
+import { downloadSubtitles } from '../utils/subtitles';
 
 interface DownloadMetadata {
 	url: URL;
@@ -154,6 +155,16 @@ export const useDownloadHandler = (enabled = false) => {
 			// Download the file
 			await resumable.downloadAsync();
 			download.status = DownloadStatus.Complete;
+
+			// Download any subtitle tracks alongside the video file
+			if (download.item.MediaType === MediaType.Video) {
+				try {
+					await downloadSubtitles(api, download);
+				} catch (e) {
+					// Subtitle downloads are best-effort and should not fail the download
+					console.warn('[useDownloadHandler] Failed to download subtitles', e instanceof Error ? e.message : e);
+				}
+			}
 
 			// Report transcoding download has stopped so the server will cleanup temp files
 			if (downloadMetadata.isTranscoding) {

--- a/features/downloads/utils/__tests__/subtitles.test.js
+++ b/features/downloads/utils/__tests__/subtitles.test.js
@@ -1,0 +1,98 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { MediaStreamType } from '@jellyfin/sdk/lib/generated-client/models/media-stream-type';
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
+import * as FileSystem from 'expo-file-system';
+
+import DownloadModel from '../../../../models/DownloadModel';
+import { deleteSubtitles, getSubtitleFileName, getSubtitleStreams } from '../subtitles';
+
+jest.mock('expo-file-system');
+
+describe('getSubtitleStreams', () => {
+	it('should return subtitle streams from the first media source', () => {
+		const streams = getSubtitleStreams([{
+			Id: 'media-source-id',
+			MediaStreams: [
+				{ Type: MediaStreamType.Video, Index: 0 },
+				{ Type: MediaStreamType.Audio, Index: 1 },
+				{ Type: MediaStreamType.Subtitle, Index: 2 },
+				{ Type: MediaStreamType.Subtitle, Index: 3, Language: 'spa' }
+			]
+		}]);
+
+		expect(streams).toEqual([
+			{ Type: MediaStreamType.Subtitle, Index: 2 },
+			{ Type: MediaStreamType.Subtitle, Index: 3, Language: 'spa' }
+		]);
+	});
+
+	it('should return an empty array when there are no media sources', () => {
+		expect(getSubtitleStreams(undefined)).toEqual([]);
+	});
+});
+
+describe('getSubtitleFileName', () => {
+	it('should use the stream language when available', () => {
+		expect(getSubtitleFileName('Movie (2020)', { Type: MediaStreamType.Subtitle, Index: 2, Language: 'eng' }))
+			.toBe('Movie (2020).eng.srt');
+	});
+
+	it('should fall back to the stream index without a language', () => {
+		expect(getSubtitleFileName('Movie (2020)', { Type: MediaStreamType.Subtitle, Index: 2 }))
+			.toBe('Movie (2020).2.srt');
+	});
+});
+
+describe('deleteSubtitles', () => {
+	let model;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		model = new DownloadModel(
+			{
+				Id: 'item-id',
+				ServerId: 'server-id',
+				Name: 'Movie (2020)',
+				MediaType: MediaType.Video,
+				Path: '/movies/Movie (2020).mkv'
+			},
+			'https://example.com/',
+			'api-key',
+			'Movie (2020).mkv',
+			'https://example.com/download'
+		);
+	});
+
+	it('should delete only the subtitle files that match the video file name', async () => {
+		FileSystem.getInfoAsync.mockResolvedValue({ exists: true, isDirectory: true });
+		FileSystem.readDirectoryAsync.mockResolvedValue([
+			'Movie (2020).mkv',
+			'Movie (2020).eng.srt',
+			'Movie (2020).spa.srt',
+			'other.txt'
+		]);
+
+		await deleteSubtitles(model);
+
+		const expected = [
+			encodeURI(model.localPath + 'Movie (2020).eng.srt'),
+			encodeURI(model.localPath + 'Movie (2020).spa.srt')
+		];
+		expect(FileSystem.deleteAsync).toHaveBeenCalledTimes(2);
+		expect(FileSystem.deleteAsync.mock.calls.map(call => call[0])).toEqual(expect.arrayContaining(expected));
+	});
+
+	it('should not delete when the download is missing', async () => {
+		FileSystem.getInfoAsync.mockResolvedValue({ exists: false });
+
+		await deleteSubtitles(model);
+
+		expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+	});
+});

--- a/features/downloads/utils/subtitles.ts
+++ b/features/downloads/utils/subtitles.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2026 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import type { Api } from '@jellyfin/sdk/lib/api';
+import { AUTHORIZATION_PARAMETER } from '@jellyfin/sdk/lib/constants';
+import type { MediaSourceInfo } from '@jellyfin/sdk/lib/generated-client/models/media-source-info';
+import type { MediaStream } from '@jellyfin/sdk/lib/generated-client/models/media-stream';
+import { MediaStreamType } from '@jellyfin/sdk/lib/generated-client/models/media-stream-type';
+import { getMediaInfoApi } from '@jellyfin/sdk/lib/utils/api/media-info-api';
+import * as FileSystem from 'expo-file-system';
+
+import type DownloadModel from '../../../models/DownloadModel';
+import { getDeviceProfile } from '../../../utils/Device';
+
+import { toDownloadProfile } from './profile';
+
+/** Gets the subtitle streams for a video media source. */
+export function getSubtitleStreams(mediaSources: MediaSourceInfo[] | null | undefined): MediaStream[] {
+	const mediaStreams = mediaSources?.[0]?.MediaStreams || [];
+	return mediaStreams.filter(
+		stream => stream.Type === MediaStreamType.Subtitle && typeof stream.Index === 'number'
+	);
+}
+
+/** Gets a subtitle file name derived from the video's file name. */
+export function getSubtitleFileName(baseName: string, stream: MediaStream): string {
+	const language = stream.Language?.trim();
+	return `${baseName}.${language || stream.Index}.srt`;
+}
+
+/**
+ * Deletes any downloaded subtitle files that share the given video file name.
+ * Uses the item's downloaded folder, so this must only be called for video downloads.
+ */
+export const deleteSubtitles = async (download: DownloadModel): Promise<void> => {
+	const dirInfo = await FileSystem.getInfoAsync(download.localPathUri);
+	if (!dirInfo.exists || !dirInfo.isDirectory) return;
+
+	const baseName = download.localFilename.slice(0, download.localFilename.lastIndexOf('.'));
+	const entries = await FileSystem.readDirectoryAsync(download.localPathUri);
+
+	await Promise.all(entries
+		.filter(entry => entry.startsWith(`${baseName}.`) && entry.endsWith('.srt'))
+		.map(entry => FileSystem.deleteAsync(
+			encodeURI(download.localPath + entry),
+			{ idempotent: true }
+		)));
+};
+
+/** Downloads the subtitles for a video item into the same folder as the video. */
+export const downloadSubtitles = async (api: Api, download: DownloadModel): Promise<void> => {
+	// Fetch the media sources so we can enumerate the available subtitle tracks
+	const { data: playbackInfo } = await getMediaInfoApi(api)
+		.getPostedPlaybackInfo({
+			itemId: download.item.Id,
+			playbackInfoDto: {
+				DeviceProfile: toDownloadProfile(getDeviceProfile())
+			}
+		});
+
+	const mediaSources = playbackInfo.MediaSources || [];
+	const mediaSourceId = mediaSources[0]?.Id;
+	const streams = getSubtitleStreams(mediaSources);
+	if (!mediaSourceId || streams.length < 1) return;
+
+	const baseName = download.localFilename.slice(0, download.localFilename.lastIndexOf('.'));
+	const serverUrl = download.serverUrl.endsWith('/') ? download.serverUrl.slice(0, -1) : download.serverUrl;
+	const usedNames = new Set<string>();
+
+	await Promise.all(streams.map(async stream => {
+		// Avoid overwriting when a media source has multiple streams for the same language
+		let fileName = getSubtitleFileName(baseName, stream);
+		if (usedNames.has(fileName)) {
+			fileName = `${baseName}.${stream.Language?.trim() || stream.Index}.${stream.Index}.srt`;
+		}
+		usedNames.add(fileName);
+
+		const url = new URL(
+			`/Videos/${download.item.Id}/${mediaSourceId}/Subtitles/${stream.Index}/Stream.srt`,
+			serverUrl
+		);
+		url.searchParams.set(AUTHORIZATION_PARAMETER, download.apiKey);
+
+		const fileUri = encodeURI(download.localPath + fileName);
+		await FileSystem.downloadAsync(url.toString(), fileUri);
+
+		console.debug('[subtitles] downloaded "%s"', fileName);
+	}));
+};

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -23,6 +23,7 @@ import DownloadListItem from '../features/downloads/components/DownloadListItem'
 import { DownloadAction } from '../features/downloads/constants/DownloadAction';
 import { DownloadStatus } from '../features/downloads/constants/DownloadStatus';
 import { getDownloadItemActions } from '../features/downloads/utils/downloadItemActions';
+import { deleteSubtitles } from '../features/downloads/utils/subtitles';
 import { useStores } from '../hooks/useStores';
 import type DownloadModel from '../models/DownloadModel';
 import { getFilesUri } from '../utils/File';
@@ -47,6 +48,9 @@ const DownloadScreen = () => {
 		try {
 			// Delete the download file
 			await FileSystem.deleteAsync(download.uri, { idempotent: true });
+
+			// Delete any subtitle files downloaded alongside the video
+			await deleteSubtitles(download);
 
 			// Get the path for each subdirectory the item exists in descending order
 			// i.e. [ 'Downloads/Series Name/Season 1/', 'Downloads/Series Name/', 'Downloads/' ]


### PR DESCRIPTION
### Changes

When a video is downloaded for offline viewing, the app only saved the video file itself. Any subtitle tracks available on the server (embedded in the container or stored as separate files) were skipped.

This change fetches the item's media source after the video download finishes and, for each available subtitle stream, saves a `.srt` file next to the video in the same downloaded folder. SRT was chosen because it is plain text, small, and broadly compatible with other apps/players that can open the downloaded video.

- New `features/downloads/utils/subtitles.ts`: fetches media info, filters subtitle streams, builds the subtitle download URL, and writes each track. Also provides a `deleteSubtitles` helper so removing a download also removes its paired subtitle files instead of leaving orphans in the folder.
- `useDownloadHandler`: after a video finishes downloading, calls `downloadSubtitles`. Subtitle failures are treated as best-effort and logged, so a problem with subtitles never fails the video download itself.
- `DownloadScreen`: calls `deleteSubtitles` when a download is deleted.
- New unit tests for the subtitle helpers.

Subtitle files are named from the video's file name (e.g. `Movie (2020).eng.srt`), falling back to the stream index when no language is set, and de-duplicated when a source has multiple tracks in the same language.

### Issues

References #372 (one of its unchecked items: "Support subtitles for downloads"). The download improvement tracking issue remains open.

### Code assistance

Code was drafted with AI assistance as an aid and reviewed against the existing download code style. I understand the changes and can explain/justify them; the approach above is mine.

----

**Testing note:** I am unable to run the iOS build or test on a device from my environment. Subtitles were validated here via `lint`, `tsc`, and the Jest unit tests (all passing). The runtime download path has not been exercised end-to-end on an iPhone yet and may need device verification. Everything else is ready for review.
