### PR TITLE
Add ability to delete failed and missing downloads

### DIFF
--- a/features/downloads/components/DownloadStatusIndicator.tsx
+++ b/features/downloads/components/DownloadStatusIndicator.tsx
@@ -21,6 +21,61 @@ import { DownloadAction } from '../constants/DownloadAction';
 import { DownloadStatus } from '../constants/DownloadStatus';
 import type { DownloadItemAction } from '../types/downloadItemAction';
 
+/** Renders a status icon for a download item. */
+const StatusIcon: FC<{ status: DownloadStatus }> = ({
+	status
+}) => {
+	const { theme } = useContext(ThemeContext);
+
+	switch (status) {
+		case DownloadStatus.Complete:
+			return null;
+		case DownloadStatus.Downloading:
+			return (
+				<ActivityIndicator
+					testID='loading-indicator'
+					style={{
+						alignSelf: 'center'
+					}}
+				/>
+			);
+		case DownloadStatus.Failed:
+			return (
+				<ListItem.Chevron
+					testID='failed-icon'
+					type='ionicon'
+					name={getIconName('warning')}
+					color={theme.colors?.error}
+					style={{
+						marginEnd: 8
+					}}
+				/>
+			);
+		case DownloadStatus.Pending:
+			return (
+				<ListItem.Chevron
+					type='ionicon'
+					name='cloud-download-outline'
+					color={theme.colors?.black}
+					style={{
+						marginEnd: 8
+					}}
+				/>
+			);
+		default:
+			return (
+				<ListItem.Chevron
+					type='ionicon'
+					name={getIconName('help-circle')}
+					color={theme.colors?.black}
+					style={{
+						marginEnd: 8
+					}}
+				/>
+			);
+	}
+};
+
 interface DownloadStatusIndicatorProps {
 	download: DownloadModel;
 	isEditMode?: boolean;
@@ -28,6 +83,7 @@ interface DownloadStatusIndicatorProps {
 	onAction: (action: DownloadAction) => void;
 }
 
+/** Status icon and menu (when supported) for download list items. */
 const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	download,
 	isEditMode = false,
@@ -35,7 +91,6 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	onAction
 }) => {
 	const { settingStore } = useStores();
-	const { theme } = useContext(ThemeContext);
 	const { t } = useTranslation();
 
 	/** Map DownloadItemActions to MenuActions. */
@@ -72,55 +127,31 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 		else console.warn('[DownloadStatusIndicator.onMenuPress] unhandled menu press action', nativeEvent.event);
 	}, [ onAction ]);
 
-	switch (download.status) {
-		case DownloadStatus.Complete:
-			return (
-				<MenuViewButton
-					testID='menu-view'
-					actions={menuActions}
-					onPressAction={onMenuPress}
-					shouldOpenOnLongPress={false}
-					themeVariant={
-						settingStore.getTheme().dark ? 'dark' : 'light'
-					}
-					disabled={isEditMode}
-				/>
-			);
-		case DownloadStatus.Downloading:
-			return (
-				<ActivityIndicator
-					testID='loading-indicator'
-					style={{
-						alignSelf: 'center'
-					}}
-				/>
-			);
-		case DownloadStatus.Failed:
-			return (
-				<ListItem.Chevron
-					testID='failed-icon'
-					type='ionicon'
-					name={getIconName('warning')}
-					color={theme.colors?.error}
-				/>
-			);
-		case DownloadStatus.Pending:
-			return (
-				<ListItem.Chevron
-					type='ionicon'
-					name='cloud-download-outline'
-					color={theme.colors?.black}
-				/>
-			);
-		default:
-			return (
-				<ListItem.Chevron
-					type='ionicon'
-					name={getIconName('help-circle')}
-					color={theme.colors?.black}
-				/>
-			);
+	const menuButton = (
+		<MenuViewButton
+			testID='menu-view'
+			actions={menuActions}
+			onPressAction={onMenuPress}
+			shouldOpenOnLongPress={false}
+			themeVariant={
+				settingStore.getTheme().dark ? 'dark' : 'light'
+			}
+			disabled={isEditMode}
+		/>
+	);
+
+	if (!download.isComplete) {
+		return (
+			<StatusIcon status={download.status} />
+		);
 	}
+
+	return (
+		<>
+			<StatusIcon status={download.status} />
+			{menuButton}
+		</>
+	);
 };
 
 DownloadStatusIndicator.displayName = 'DownloadStatusIndicator';

--- a/features/downloads/components/DownloadStatusIndicator.tsx
+++ b/features/downloads/components/DownloadStatusIndicator.tsx
@@ -127,19 +127,6 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 		else console.warn('[DownloadStatusIndicator.onMenuPress] unhandled menu press action', nativeEvent.event);
 	}, [ onAction ]);
 
-	const menuButton = (
-		<MenuViewButton
-			testID='menu-view'
-			actions={menuActions}
-			onPressAction={onMenuPress}
-			shouldOpenOnLongPress={false}
-			themeVariant={
-				settingStore.getTheme().dark ? 'dark' : 'light'
-			}
-			disabled={isEditMode}
-		/>
-	);
-
 	if (!download.isComplete) {
 		return (
 			<StatusIcon status={download.status} />
@@ -149,7 +136,16 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	return (
 		<>
 			<StatusIcon status={download.status} />
-			{menuButton}
+			<MenuViewButton
+				testID='menu-view'
+				actions={menuActions}
+				onPressAction={onMenuPress}
+				shouldOpenOnLongPress={false}
+				themeVariant={
+					settingStore.getTheme().dark ? 'dark' : 'light'
+				}
+				disabled={isEditMode}
+			/>
 		</>
 	);
 };

--- a/features/downloads/utils/downloadItemActions.ts
+++ b/features/downloads/utils/downloadItemActions.ts
@@ -10,9 +10,11 @@ import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type'
 
 import type DownloadModel from '../../../models/DownloadModel';
 import { DownloadAction } from '../constants/DownloadAction';
+import { DownloadStatus } from '../constants/DownloadStatus';
 import type { DownloadItemAction } from '../types/downloadItemAction';
 
 export const getDownloadItemActions = (download: DownloadModel): DownloadItemAction[] => {
+	const isComplete = download.status === DownloadStatus.Complete;
 	// NOTE: Currently only video has a native UI to play within the app.
 	// The media type check should be removed when we have a native audio player UI available.
 	const isPlayableInApp = download.canPlay && (
@@ -27,7 +29,7 @@ export const getDownloadItemActions = (download: DownloadModel): DownloadItemAct
 			image: 'play',
 			isDefault: true,
 			isEnabled: true,
-			isSupported: isPlayableInApp
+			isSupported: isComplete && isPlayableInApp
 		},
 		{
 			id: DownloadAction.OpenInFiles,
@@ -35,14 +37,14 @@ export const getDownloadItemActions = (download: DownloadModel): DownloadItemAct
 			image: 'folder',
 			isDefault: true,
 			isEnabled: true,
-			isSupported: true
+			isSupported: isComplete
 		},
 		{
 			id: DownloadAction.Share,
 			title: 'common.share',
 			image: 'square.and.arrow.up',
 			isEnabled: true,
-			isSupported: true
+			isSupported: isComplete
 		},
 		{
 			id: DownloadAction.Delete,

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -27,6 +27,9 @@ import { useStores } from '../hooks/useStores';
 import type DownloadModel from '../models/DownloadModel';
 import { getFilesUri } from '../utils/File';
 
+/** The statuses that indicate a download should not exist on the file system. */
+const NO_FILE_STATUSES = new Set<DownloadStatus>([ DownloadStatus.Failed, DownloadStatus.Pending ]);
+
 const Hairline = () => <View style={{ height: StyleSheet.hairlineWidth }} />;
 
 const DownloadScreen = () => {
@@ -107,25 +110,25 @@ const DownloadScreen = () => {
 	}, [ deleteItem, exitEditMode, t ]);
 
 	const onAction = useCallback(async (action: DownloadAction, item: DownloadModel) => {
-		// TODO: Allow retrying/removing failed downloads
-		if (item.status === DownloadStatus.Failed) return;
-
 		// Verify the download has not been removed from the file system
-		const info = await FileSystem.getInfoAsync(item.uri);
-		if (!info.exists) {
-			if (item.status !== DownloadStatus.Missing) {
-				item.status = DownloadStatus.Missing;
+		if (!NO_FILE_STATUSES.has(item.status)) {
+			const info = await FileSystem.getInfoAsync(item.uri);
+			if (!info.exists) {
+				if (item.status !== DownloadStatus.Missing) {
+					item.status = DownloadStatus.Missing;
+					downloadStore.update(item);
+
+					Alert.alert(
+						t('alerts.missingDownload.title'),
+						t('alerts.missingDownload.description')
+					);
+					return;
+				}
+			} else if (item.status === DownloadStatus.Missing) {
+				// The download exists so update the status
+				item.status = DownloadStatus.Complete;
 				downloadStore.update(item);
 			}
-			Alert.alert(
-				t('alerts.missingDownload.title'),
-				t('alerts.missingDownload.description')
-			);
-			return;
-		} else if (item.status === DownloadStatus.Missing) {
-			// The download exists so update the status
-			item.status = DownloadStatus.Complete;
-			downloadStore.update(item);
 		}
 
 		switch (action) {

--- a/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
+++ b/screens/__tests__/__snapshots__/DownloadScreen.test.js.snap
@@ -252,7 +252,13 @@ exports[`DownloadScreen should render correctly 1`] = `
                 }
               }
             >
-              <View>
+              <View
+                style={
+                  Object {
+                    "marginEnd": 8,
+                  }
+                }
+              >
                 <View
                   style={
                     Object {
@@ -406,7 +412,13 @@ exports[`DownloadScreen should render correctly 1`] = `
                 }
               }
             >
-              <View>
+              <View
+                style={
+                  Object {
+                    "marginEnd": 8,
+                  }
+                }
+              >
                 <View
                   style={
                     Object {


### PR DESCRIPTION
### Changes
Enables deleting failed and missing downloads via the menu

### Issues
Part of #372 

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
